### PR TITLE
AOT Compilation, Shape Inference

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,7 +60,7 @@ Everything is a syntax sugar for ./source/air.
 
 Please declare devices capable of AOT compilation in the environment variables AOT and AOT_VM.
 
-```AOT_VM=LISP AOT_JIT=CLANG,LISP make test``
+```AOT_VM=LISP AOT_JIT=CLANG,LISP make test```
 
 Afterwards, functions defined using the caten/defun macro will undergo AOT compilation. (Note that it does not analyze the source code, but traces the computational graph through Shape Tracker and lazy evaluation, so it does not behave exactly like defun).
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,38 @@
 # Caten
 
-Caten = Compile+AbstracTENsor
+- [ ] Short-term goal: Finish for ELS 2025
+
+> **This repository is still in the early stages of development. Additionally, it includes many experimental approaches. Please consider this as a place to experiment with my ideas. Do not use it in a product under any circumstances.**
+
+`Caten = Compile+AbstracTENsor`
 
 something between tvm and tinygrad.
 
-- [ ] Finish this for ELS 2025
+Caten is an extremely experimental deep learning compiler. The core design philosophy is centered around:
+
+1. Minimal dependency libraries
+
+2. Maintainable code with fewer lines (should be less than 10,000 lines excluding tests)
+
+3. An easily extendable Renderer (like tinygrad) that can adapt to any device with minimal code
+
+4. **Ahead-of-time** Compilation and Shape Inference
+
+5. Usable as a command-line tool based on Roswell (of course, also available from Common Lisp, and Coalton in the future.)
+
+6. A framework that significantly simplifies debugging (which is a full of pain for us) via a REPL-based approach.
+
+Ultimately, Caten aims to generate runtime executables in C (based on our any-to-any renderer) and eliminate dependencies even on Common Lisp, thereby achieving high portability for inference. (This means that the implementation methods for `./source/apis/control-flow.lisp` elements like If and For need careful consideration.)
+
+To achieve the above goals, Caten adopts a compiler-based approach. We do not write any kernels for matrix operations. Instead, we represent computations using a lazy evaluation approach and a fast, simple computational graph (Caten/AIR). We simplify the computational graph using a dedicated Pattern Matcher, and ultimately, optimized kernels for CPUs and GPUs are generated using a Polyhedral Compiler. At the same time, a VM for precision verification has been implemented, with JIT positioned as a subset for VM acceleration.
+
+For the implementation of automatic differentiation and (in the future) quantization, it is crucial to facilitate easy rewriting of the computational graph. Caten's computation phase has multiple stages of Lowering, in which rewriting of the computational graph is possible at every stage using a Pattern Matcher. The smallest computational graph is a Func, declared in `./source/aasm/`. This graph is used ultimately for Rendering or VM execution, and the number of computations should be minimized through function composition. A Func can be obtained by Lowering a Module, which defines computations that can be composed (e.g., Matmul, Conv2D, Cos). For example, in cases where automatic differentiation cannot ensure computational accuracy, like with Sigmoid, it's possible to describe Backward at the Module level, as well as rewrite computations at the Module level.
+
+The `Caten/AIR` graph used at runtime should be dumpable in a format compatible with Common Lisp. Ultimately, the computational graph used should be expressed solely as a list comprised of Number, Symbol, Keyword.
+
+Nearly all of Caten's APIs support Symbolic Compilation, allowing for compilation with symbols instead of numbers where required, as in `(make-tensor '(a b c) :initial-element 'x)`. To implement this, Caten involves even the computation of Shape and Stride within the lazy evaluation graph (just like Numpy, Shape can be treated as fixed when the Pattern Matcher performs Constant Folding).
+
+In the future, I would like to reimplement the frontend in Coalton.
 
 ## Project Structure (WIP)
 
@@ -19,7 +47,7 @@ Everything is a syntax sugar for ./source/air.
 4 | ./source/meta    | Meta Programming Library (incl. Source Code Transformation)
 --- frontend -----------------------------------------------------------------------
 5 | ./source/lang    | a compiler from lisp to aIR (helping the complicated subscript notation like Conv/einsum) 
-6 | ./source/api     | Syntax sugar for core notations, including AbstractTensor, autodiff engine. (-> ./source/package.lisp?)
+6 | ./source/apis    | Syntax sugar for core notations, including AbstractTensor, autodiff engine. (-> ./source/package.lisp?)
 7 | ./source/nn      | a syntax sugar which implements nn ops and optimizers
 --- external -----------------------------------------------------------------------
 ./external/avm/clang  | avm implementation using clang
@@ -28,69 +56,33 @@ Everything is a syntax sugar for ./source/air.
 ------------------------------------------------------------------------------------
 ```
 
+## Enable AOT Compilation
+
+Please declare devices capable of AOT compilation in the environment variables AOT and AOT_VM.
+
+```AOT_VM=LISP AOT_JIT=CLANG,LISP make test``
+
+Afterwards, functions defined using the caten/defun macro will undergo AOT compilation. (Note that it does not analyze the source code, but traces the computational graph through Shape Tracker and lazy evaluation, so it does not behave exactly like defun).
+
+```lisp
+(caten/defun[float] (axpy! "axpy") (x y n froma toa bya fromb tob byb)
+  (!add (!view (make-tensor `(,n) :from x) `(,froma ,toa ,bya)) (!view (make-tensor `(,n) :from y) `(,fromb ,tob ,byb)))) 
 ```
-Composite (e.g.: Linera, Conv2d) -> [Lower] -> Function (e.g.: Add) -> [Lower] -> ASM (e.g.: %add)
--> [Lower] -> AJit
-or
--> AVM
-```
 
-## TODO
-
-- pre-commit
-
-## Testing
+## Running the unittest
 
 ```sh
-$ COVERAGE=1 qlot exec rove caten.asd
+# either of
+$ COVERAGE=1 rove caten.asd
+$ make test
 ```
-
-## The Goal
-
-- (!!!) From ONNX to Pure C Compiler for the inference mode.
-
-- Export To ONNX/From ONNX to Caten
-
-- Do not provide an implementation which specializes on a certain device in `./source`.
-
-- Hackable Polyhedral Compiler
-
-- "compilation time" graph simplification and type inference
-
-- beautiful docgen system
-
-- Numpy Style + Trace from lisp mode
-
-- Implement approxs for sin/log2/exp2
-
-- Symbolic Compilation
-
-- (In the future) reimplement the frontend in Coalton
-
-- MoEのGatingとかKV CacheをうまくCにExportできるIRを考える
-
-    - `:Graph`の名前空間にLoweringしないやつを作る (If/For/DefModule)
-
-- Dot or ONNX render at ./caten/air
-
-- Source code transformation (needs a refactor; caten/air must corresponds Func one-by-one.)
-
-    - Func/Moduleのもう一段階上のGraphを作ってSimplifyするようにする
 
 ## Installing (WIP)
 
 ```sh
-$ ros install hikettei/caten
-$ caten --help
 $ brew install isl
 ```
 
 ## Dependencies
 
-- trivia
-
-- alexandria
-
-- rove
-
-- cl-ppcre
+- ISL

--- a/source/aasm/tensor-ir.lisp
+++ b/source/aasm/tensor-ir.lisp
@@ -61,7 +61,10 @@ If i is a tensor, %load fills the visible area of i with value."
 	      (render-list (subseq (node-reads node) 0 nrank))
 	      (render-list (subseq (node-reads node) nrank))
 	      (if (getattr node :from)
-		  (format nil ", from=<~a Realized Array>" (uiop:symbol-call :caten/avm :buffer-shape (getattr node :from)))
+		  (let ((buffer (getattr node :from)))
+		    (if (symbolp buffer)
+			(format nil ", from=<~a, Realized Array>" buffer)
+			(format nil ", from=<~a Realized Array>" (uiop:symbol-call :caten/avm :buffer-shape buffer))))
 		  "")
 	      (render-attrs node :except-for `(:from))))))
 

--- a/source/air/node.lisp
+++ b/source/air/node.lisp
@@ -34,15 +34,15 @@
   (reads  reads :type list)
   (attrs  attrs :type list))
 
-(deftype dumpable-type () `(or symbol number keyword list))
+(deftype dumpable-type () `(or symbol number keyword))
 (defmethod make-load-form ((node Node) &optional env &aux (debug-dump (= 1 (ctx:getenv :AOT_VERBOSE))))
   (declare (ignore env))
   `(make-node
     ,(node-class node) ,(node-type node) ',(node-writes node) ',(node-reads node)
     ,@(loop for attr in (getattrs node)
 	    for val = (getattr node attr)
-	    if (typep val 'dumpable-type)
-	      append (if (and (symbolp val) (not (keywordp val)))
+	    if (or (typep val 'dumpable-type) (and (listp val) (every #'(lambda (x) (typep x 'dumpable-type)) val)))
+	      append (if (or (listp val) (and (symbolp val) (not (keywordp val))))
 			 `(,attr ',val)
 			 `(,attr ,val))
 	    else

--- a/source/air/node.lisp
+++ b/source/air/node.lisp
@@ -41,7 +41,7 @@
     ,(node-class node) ,(node-type node) ',(node-writes node) ',(node-reads node)
     ,@(loop for attr in (getattrs node)
 	    for val = (getattr node attr)
-	    if (or (typep val 'dumpable-type) (and (listp val) (every #'(lambda (x) (typep x 'dumpable-type)) val)))
+	    if (or (eql attr :jit-info) (typep val 'dumpable-type) (and (listp val) (every #'(lambda (x) (typep x 'dumpable-type)) val)))
 	      append (if (or (listp val) (and (symbolp val) (not (keywordp val))))
 			 `(,attr ',val)
 			 `(,attr ,val))

--- a/source/ajit/backends/clang.lisp
+++ b/source/ajit/backends/clang.lisp
@@ -49,21 +49,19 @@ Compiled with: ~a"
 			  (,@(node-writes (car rest-forms)) (buffer-value ,@(node-writes (car rest-forms))))
 			,(expand (cdr rest-forms) body)))
 		 `(progn ,@body))))
-    (compile
-     nil
-     `(lambda (,@(apply #'append (map 'list #'node-writes allocs)))
-	(declare (optimize (compilation-speed 3)))
-	,(expand
-	  allocs
-	  `((cffi:foreign-funcall
-	     ,(format nil "~(~a~)" (avm-name avm))
-	     ,@(loop for node in allocs
-		     for type = (->cffi-dtype(getattr node :dtype))
-		     if (= (getattr node :nrank) 0)
-		       append `(,type (dtype/cast (buffer-value ,(car (node-writes node))) ,(getattr node :dtype)))
-		     else
-		       append `(:pointer ,(car (node-writes node))))
-	     :void)))))))
+    `(lambda (,@(apply #'append (map 'list #'node-writes allocs)))
+       (declare (optimize (compilation-speed 3)))
+       ,(expand
+	 allocs
+	 `((cffi:foreign-funcall
+	    ,(format nil "~(~a~)" (avm-name avm))
+	    ,@(loop for node in allocs
+		    for type = (->cffi-dtype(getattr node :dtype))
+		    if (= (getattr node :nrank) 0)
+		      append `(,type (dtype/cast (buffer-value ,(car (node-writes node))) ,(getattr node :dtype)))
+		    else
+		      append `(:pointer ,(car (node-writes node))))
+	    :void))))))
 
 (defun render-to-c (obj)
   (let ((obj (format nil "~(~a~)" obj)))

--- a/source/ajit/simplifiers.lisp
+++ b/source/ajit/simplifiers.lisp
@@ -175,7 +175,7 @@
 	for write-to = (case (node-type node) (:ALLOCATE nil) (:WHERE (second (node-reads node))) (otherwise (car (node-reads node))))
 	if (eql write-to id)
 	  collect node))
-;; MULTIEXPR ... JIT関数作成時点で適用，Groupingの流れにする
+
 (defun apply-memory-planner (refcount pipeline avm schedule-graph)
   (let* ((pipeline-ids (loop for r in (graph-nodes schedule-graph) if (eql (node-type r) :FUNCALL) collect (getattr r :idx)))
 	 (alloc-ids (loop for k in (hash-table-keys pipeline) unless (find k pipeline-ids) collect k))

--- a/source/apis/ahead-of-time.lisp
+++ b/source/apis/ahead-of-time.lisp
@@ -1,5 +1,6 @@
 (in-package :caten/apis)
 ;; TODO: Documentation
+;; TODO: Involve them unittests
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defparameter *aot-jit* (ctx:getenv :AOT))
   (defparameter *aot-vm* (ctx:getenv :AOT_VM))
@@ -57,18 +58,11 @@
     `(caten/defun[T] (,name ,cffi-prefix :dtypes (:uint64 :uint32 :uint16 :uint8)) (,@lambda-list) ,@body)))
 
 ;; [TODO] Unbind all methods when redefining the method.
-(caten/defun[T] (axpy "axpy" :dtypes (:float32)) (x y n froma toa bya fromb tob byb)
-  (!add (!view (make-tensor `(,n) :from x) `(,froma ,toa ,bya)) (!view (make-tensor `(,n) :from y) `(,fromb ,tob ,byb)))) 
+;;(caten/defun[T] (axpy "axpy" :dtypes (:float32)) (x y n froma toa bya fromb tob byb)
+;;  (!add (!view (make-tensor `(,n) :from x) `(,froma ,toa ,bya)) (!view (make-tensor `(,n) :from y) `(,fromb ,tob ,byb)))) 
 
 ;;(caten/defun[T] (%rand "rand" :dtypes (:float32)) (size)
 ;;  (!rand `(,size) :dtype :float32))
 
 ;;(caten/defun[T] (gemm! "gemm" :dtypes (:float32)) (x y m n k)
 ;;  (!matmul (make-tensor `(,m ,n) :from x) (make-tensor `(,n ,k) :from y)))
-
-;; Problems w/ CLANG JIT? (OK)
-;; TODO: Load Tensor (OK)
-;; Test with clang
-;; Switch to JIT (OK)
-;; How to dump clang code?
-;; TODO: ContextVar (OK)

--- a/source/apis/ahead-of-time.lisp
+++ b/source/apis/ahead-of-time.lisp
@@ -58,8 +58,8 @@
     `(caten/defun[T] (,name ,cffi-prefix :dtypes (:uint64 :uint32 :uint16 :uint8)) (,@lambda-list) ,@body)))
 
 ;; [TODO] Unbind all methods when redefining the method.
-;;(caten/defun[T] (axpy "axpy" :dtypes (:float32)) (x y n froma toa bya fromb tob byb)
-;;  (!add (!view (make-tensor `(,n) :from x) `(,froma ,toa ,bya)) (!view (make-tensor `(,n) :from y) `(,fromb ,tob ,byb)))) 
+(caten/defun[T] (axpy "axpy" :dtypes (:float32)) (x y n froma toa bya fromb tob byb)
+  (!add (!view (make-tensor `(,n) :from x) `(,froma ,toa ,bya)) (!view (make-tensor `(,n) :from y) `(,fromb ,tob ,byb)))) 
 
 ;;(caten/defun[T] (%rand "rand" :dtypes (:float32)) (size)
 ;;  (!rand `(,size) :dtype :float32))

--- a/source/apis/ahead-of-time.lisp
+++ b/source/apis/ahead-of-time.lisp
@@ -54,5 +54,5 @@
 
 ;; [TODO] Implement BLAS
 ;; should be separated from the main package though to avoid compilation error
-;;(caten/defun[T] (axpy! "axpy" :dtypes (:float32)) (n froma toa bya fromb tob byb)
-;;  (!add (!view (make-tensor `(,n)) `(,froma ,toa ,bya)) (!view (make-tensor `(,n)) `(,fromb ,tob ,byb)))) 
+(caten/defun[T] (axpy! "axpy" :dtypes (:float32)) (n froma toa bya fromb tob byb)
+  (!add (!view (make-tensor `(,n)) `(,froma ,toa ,bya)) (!view (make-tensor `(,n)) `(,fromb ,tob ,byb)))) 

--- a/source/apis/ahead-of-time.lisp
+++ b/source/apis/ahead-of-time.lisp
@@ -58,8 +58,8 @@
     `(caten/defun[T] (,name ,cffi-prefix :dtypes (:uint64 :uint32 :uint16 :uint8)) (,@lambda-list) ,@body)))
 
 ;; [TODO] Unbind all methods when redefining the method.
-(caten/defun[T] (axpy "axpy" :dtypes (:float32)) (x y n froma toa bya fromb tob byb)
-  (!add (!view (make-tensor `(,n) :from x) `(,froma ,toa ,bya)) (!view (make-tensor `(,n) :from y) `(,fromb ,tob ,byb)))) 
+;;(caten/defun[T] (axpy "axpy" :dtypes (:float32)) (x y n froma toa bya fromb tob byb)
+;;  (!add (!view (make-tensor `(,n) :from x) `(,froma ,toa ,bya)) (!view (make-tensor `(,n) :from y) `(,fromb ,tob ,byb)))) 
 
 ;;(caten/defun[T] (%rand "rand" :dtypes (:float32)) (size)
 ;;  (!rand `(,size) :dtype :float32))

--- a/source/apis/function.lisp
+++ b/source/apis/function.lisp
@@ -32,7 +32,8 @@ save-for-backward is determined automatically, so you do not have to consider ab
 (defclass Allocate (Func)
   ((buffer :initarg :buffer :type Tensor :accessor alloc-buffer)
    (initial-element :initarg :initial-element :initform nil :accessor alloc-initial-element)
-   (id :initform nil :accessor alloc-id)))
+   (id :initform nil :accessor alloc-id)
+   (from :initform nil :initarg :from :accessor alloc-from)))
 (defmethod forward ((op Allocate) &rest tensors) (declare (ignore tensors)) (alloc-buffer op))
 (defmethod backward ((op Allocate) &optional dout)
   (let ((buff (alloc-buffer op)))
@@ -52,7 +53,7 @@ save-for-backward is determined automatically, so you do not have to consider ab
       (let ((g
 	      (with-context
 		(s (map 'list #'->lower (tensor-shape buff)))
-		(a (%make-tensor s :dtype (tensor-dtype buff) :order (tensor-order buff) :id (tensor-id buff)))
+		(a (%make-tensor s :dtype (tensor-dtype buff) :order (tensor-order buff) :id (tensor-id buff) :from (alloc-from op)))
 		(a (when (alloc-initial-element op) (%load a (alloc-initial-element op)))))))
 	(push g nodes)
 	(apply #'make-graph (apply #'append (map 'list #'graph-nodes (reverse nodes))))))))

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -347,16 +347,18 @@
    (avm-id2tensor avm)))
 
 (defmethod forward ((avm caten/avm:AVM) &rest params)
-  (vm/set-params avm params)
-  (vm/forward avm)
-  (avm/sync-tensors avm)
-  (apply #'values (map 'list #'(lambda (x) (%apply-proceed (gethash x (avm-id2tensor avm)))) (avm-fw-outputs avm))))
+  (let ((*device* (ctx:getenv :AVM)))
+    (vm/set-params avm params)
+    (vm/forward avm)
+    (avm/sync-tensors avm)
+    (apply #'values (map 'list #'(lambda (x) (%apply-proceed (gethash x (avm-id2tensor avm)))) (avm-fw-outputs avm)))))
 
 (defmethod backward ((avm caten/avm:AVM) &optional prev-dout)
   (declare (ignore prev-dout))
-  (vm/backward avm)
-  (avm/sync-tensors avm)
-  t)
+  (let ((*device* (ctx:getenv :AVM)))
+    (vm/backward avm)
+    (avm/sync-tensors avm)
+    t))
 
 (defun proceed (&rest tensors)
   "Realizes the tensor"
@@ -366,4 +368,3 @@
 (defun %tensor->aasm (&rest tensors)
   (let ((sess (make-compiler-session :name :tensor->aasm)))
     (%lower-iseq sess (apply #'%tpsort-tensors sess tensors))))
-

--- a/source/apis/package.lisp
+++ b/source/apis/package.lisp
@@ -12,6 +12,16 @@
    :caten/common.dtype
    #:dtype-t
    #:dtype->lisp)
+  ;; from aot-compilation.lisp
+  (:export
+   #:*aot-jit*
+   #:*aot-vm*
+   #:*invoke-aot-function*
+   #:caten/defun[t]
+   #:caten/defun[all]
+   #:caten/defun[float]
+   #:caten/defun[int]
+   #:caten/defun[uint])
   ;; from tensor.lisp
   (:export
    #:make-tensor

--- a/source/apis/tensor.lisp
+++ b/source/apis/tensor.lisp
@@ -52,7 +52,7 @@
 	  (tensor-requires-grad tensor)
 	  (map 'list #'tensor-id (tensor-variables tensor))))
 
-(defun make-tensor (shape &key (dtype *default-float*) (order *default-order*) (id (gensym "TID")) (requires-grad nil) (initial-element nil) (views nil))
+(defun make-tensor (shape &key (dtype *default-float*) (order *default-order*) (id (gensym "TID")) (requires-grad nil) (initial-element nil) (views nil) (from nil))
   "## [function] make-tensor
 Create a new lazy tensor.
 Shape := (Integer > 1) | Symbol | Tensor"
@@ -60,7 +60,8 @@ Shape := (Integer > 1) | Symbol | Tensor"
 	   (type dtype-t dtype)
 	   (type (member :column :row) order)
 	   (type symbol id)
-	   (type (or null number symbol) initial-element))
+	   (type (or null number symbol) initial-element)
+	   (type (or null symbol) from))
   (dolist (s shape)
     (assert (or (and (integerp s) (>= s 1)) (tensor-p s) (symbolp s))
 	    ()
@@ -69,7 +70,7 @@ Shape := (Integer > 1) | Symbol | Tensor"
     ;; Weird thing: The Top of the graph should not have variables.
     ;; AD recognises (null (func-variables op)) as an Allocation.
     ;; So do not modify the (tensor-variables tensor), as well as (func-variables Allocation)
-    (setf (tensor-op buff) (make-instance 'Allocate :buffer buff :initial-element initial-element))
+    (setf (tensor-op buff) (make-instance 'Allocate :buffer buff :initial-element initial-element :from from))
     buff))
 
 (defun make-scalar (value &key (dtype *default-float*) (order *default-order*) (id (gensym "SID")) (requires-grad nil))

--- a/source/apis/tensor.lisp
+++ b/source/apis/tensor.lisp
@@ -19,9 +19,10 @@
   (grad-id grad-id :type symbol)
   (variables variables :type list))
 
-(defmethod make-load-form ((tensor Tensor) &optional env)
+(defmethod make-load-form ((tensor Tensor) &optional env &aux (debug-p (= 1 (ctx:getenv :AOT_VERBOSE))))
   (declare (ignore env))
-  ;; (when (tensor-buffer tensor) (warn "the buffer of ~a may be lost" tensor))
+  (when (and (tensor-buffer tensor) debug-p)
+    (warn "Removing the buffer of ~a when dumping it." tensor))
   (values
    `(%internal-make-tensor
      nil ',(tensor-shape tensor)
@@ -117,4 +118,3 @@ Shape := (Integer > 1) | Symbol | Tensor"
 	;; Fold Constants in Shape (detached from the graph, no side effects)
 	(setf (tensor-shape buff) (map 'list #'(lambda (x) (if (tensor-p x) (or (try-fold-constant x) x) x)) (tensor-shape buff)))
 	buff))))
-

--- a/source/apis/test-suites.lisp
+++ b/source/apis/test-suites.lisp
@@ -517,3 +517,10 @@
 	      (testing "Then, reproduce second/third randomness in a single call of proceed."
 		(let* ((second-and-third-rand (elements (proceed (!add (!rand `(,n ,n)) (!rand `(,n ,n)))))))
 		  (ok (every #'= (map 'list #'+ scnd-rand third-rand) second-and-third-rand)))))))))))
+
+(caten/defun[T] (axpy "axpy" :dtypes (:float32)) (x y n froma toa bya fromb tob byb)
+  (!add (!view (make-tensor `(,n) :from x) `(,froma ,toa ,bya)) (!view (make-tensor `(,n) :from y) `(,fromb ,tob ,byb)))) 
+
+(deftest call-aot
+  (let ((a (with-device :lisp (proceed (ax+b `(3 3) 1 1)))) (b (with-device :lisp (proceed (ax+b `(3 3) 1 1)))))
+    (every #'= #(2 4 6 8 10 12 14 16 18) (elements (axpy :float32 a b 9 0 9 1 0 9 1)))))

--- a/source/avm/opset.lisp
+++ b/source/avm/opset.lisp
@@ -8,5 +8,11 @@
     (if (or (null from) (eql device-id :relay-checker))
 	(call-next-method)
 	(progn
-	  (assert (buffer-p from) () ":from attribute for ~a must be a realized buffer! (check the graph construction process.)" node)
-	  from))))
+	  (assert (or (symbolp from) (buffer-p from)) () ":from attribute for ~a must be a realized buffer! (check the graph construction process.)" node)
+	  (if (buffer-p from)
+	      from
+	      (let ((val (vm/readvar *vm* from)))
+		(if (buffer-p val)
+		    val
+		    (error "When Processing ~a, the variable ~a should be declared in the VM, and it should be a variable, getting ~a."
+			   node from val))))))))

--- a/source/avm/opset.lisp
+++ b/source/avm/opset.lisp
@@ -14,5 +14,4 @@
 	      (let ((val (vm/readvar *vm* from)))
 		(if (buffer-p val)
 		    val
-		    (error "When Processing ~a, the variable ~a should be declared in the VM, and it should be a variable, getting ~a."
-			   node from val))))))))
+		    (error "When Processing ~a, the variable ~a should be declared in the VM, and it should be a variable, getting ~a." node from val))))))))

--- a/source/avm/runtime.lisp
+++ b/source/avm/runtime.lisp
@@ -101,7 +101,7 @@
 
 (defun vm/set-params (avm params)
   (loop for (k . v) in params
-	do (assert (and (symbolp k) (numberp v))
+	do (assert (and (symbolp k) (or (buffer-p v) (numberp v)))
 		   ()
 		   "vm/set-params: Invaild params (~a . ~a)~%Params should be a cons of (symbol . number)." k v)
 	   (setf (gethash k (avm-variables avm)) v)))

--- a/source/common/caten.common.asd
+++ b/source/common/caten.common.asd
@@ -2,7 +2,7 @@
   :description "Helpers for Caten"
   :author      "hikettei <ichndm@gmail.com>"
   :licence     "MIT"
-  :depends-on ("uiop" "ieee-floats")
+  :depends-on ("uiop" "ieee-floats" "cl-ppcre")
   :serial t
   :components
   ((:file "contextvar")

--- a/source/common/contextvar.lisp
+++ b/source/common/contextvar.lisp
@@ -132,7 +132,10 @@ Usage:
      "Set 0 to disable the animated progress bar of common/tqdm.lisp")
     (:CC
      "gcc" :string identity
-     "Default C Compiler")))
+     "Default C Compiler")
+    (:AOT_VERBOSE
+     0 :int #.(oneof "AOT_VERBOSE" 0 `(0 1))
+     "")))
 
 (defparameter *ctx* (make-contextvar))
 (defmacro with-contextvar ((&rest configurations) &body body)


### PR DESCRIPTION
- [x] AOT Compilation for Symbolic Ops
- [x] Only enabled when AOT is set to 1 (in default disabled)
    - [x] If the function was called with a backend which is unknown at the compilation time? -> switch to JIT
- [x] AOT Shape Inference
- [x] AVM.dumped (unnecessary information like variables, tensors, etc, is removed)
- [x] Dump aIR (foreshadowing came together for implementing my own IR!)
    - Compiled aIR graph are only composed of number, symbol, and keyword. they can be dumped using `make-load-form`.
 - [ ] Writing tests
 - [ ] cffi objects are really dumped????