### PR TITLE
[Draft] Make JIT completely equivalent to VM (Forward Mode)

### DIFF
--- a/source/aasm/tensor-ir.lisp
+++ b/source/aasm/tensor-ir.lisp
@@ -112,7 +112,7 @@ Typed: <Allocate OUT_ID <- (,@shape ,@stride) where from=from dtype=dtype nrank=
     (return-from %make-tensor (%salloc :dtype dtype :id id)))
   (%alloc (length shape) (%shape shape) (%stride shape order) :dtype dtype :id id :from from))
 
-(defun %index-components (x &key (id (gensym "IID")))
+(defun %index-components (x shape &key (id (gensym "IID")))
   "the equivalent to doing: `for (int i=x.view.from;i<x.view.to;i+=x.view.by) { id[i] = i; }`"
-  (declare (type node x))
-  (emit (make-node :Indexing :Index-Components (list id) (list (node->id x)))))
+  (declare (type node x) (type list shape))
+  (emit (make-node :Indexing :Index-Components (list id) `(,(node->id x) ,@(map 'list #'node->id (%stride shape :row))))))

--- a/source/aasm/test-suites.lisp
+++ b/source/aasm/test-suites.lisp
@@ -92,7 +92,7 @@
 (defun %arange (shape a b &key (dtype :float32) (order :row))
   (with-context
     (m (%make-tensor shape :dtype dtype :order order))
-    (i (%index-components m))
+    (i (%index-components m (%shape shape)))
     (alpha (%load (%salloc :dtype dtype) a))
     (beta  (%load (%salloc :dtype dtype) b))
     ;; a = alpha * i + b

--- a/source/ajit/backends/clang.lisp
+++ b/source/ajit/backends/clang.lisp
@@ -168,7 +168,8 @@ Compiled with: ~a"
 (defmethod %render-expr ((lang (eql :clang)) (op (eql :INDEX-COMPONENTS)) lhs rhs z)
   (assert (buffer-p (expr-y lhs)))
   (assert (null z))
-  (format nil "(~a)" (render-isl-aref (expr-y lhs) :genid #'(lambda (x) (intern (nth x *access*))))))
+  (let ((strides (map 'list #'(lambda (x) (render-expr lang x)) rhs)))
+    (format nil "(~a)" (render-isl-aref (expr-y lhs) :genid #'(lambda (x) (intern (nth x *access*))) :strides strides))))
 
 (defmethod %render-expr ((lang (eql :clang)) (op (eql :NOT)) lhs rhs z)
   (assert (and lhs (null rhs) (null z)))
@@ -336,7 +337,7 @@ Compiled with: ~a"
 		  #.(impl-unary :SQRT "sqrt")
 		  #.(impl-unary :NOT "!")
 		  (:INDEX-COMPONENTS
-		   (line "~(~a~) = ~(~a~);" (render-aref (car (node-writes node)) (car (relay-writes type))) (render-isl-aref (car (relay-reads type)) :genid #'(lambda (x) (intern (nth x *access*))))))
+		   (line "~(~a~) = ~(~a~);" (render-aref (car (node-writes node)) (car (relay-writes type))) (render-isl-aref (car (relay-reads type)) :genid #'(lambda (x) (intern (nth x *access*))) :strides (cdr (node-reads node)))))
 		  #.(impl-binary :OR "|")
 		  #.(impl-binary :AND "&")
 		  (:WHERE

--- a/source/ajit/backends/clang.lisp
+++ b/source/ajit/backends/clang.lisp
@@ -137,7 +137,9 @@ Compiled with: ~a"
   (assert (or (stringp lhs) (symbolp lhs) (numberp lhs)))
   (assert (null z))
   (assert (null rhs))
-  (format nil "~(~a~)" (render-to-c lhs)))
+  (if (args-p lhs)
+      (format nil "(*~(~a~))" (render-to-c lhs))
+      (format nil "~(~a~)" (render-to-c lhs))))
 
 (defmethod %render-expr ((lang (eql :clang)) (op (eql :MAX)) lhs rhs z)
   (assert (and lhs rhs))

--- a/source/ajit/backends/clang.lisp
+++ b/source/ajit/backends/clang.lisp
@@ -336,7 +336,7 @@ Compiled with: ~a"
 		  #.(impl-unary :SQRT "sqrt")
 		  #.(impl-unary :NOT "!")
 		  (:INDEX-COMPONENTS
-		   (line "~(~a~) = ~(~a~);" (render-aref (car (node-writes node)) (car (relay-writes type))) (render-isl-aref (car (relay-reads type)) :genid #'(lambda (x) (intern (format nil "c~a" x))))))
+		   (line "~(~a~) = ~(~a~);" (render-aref (car (node-writes node)) (car (relay-writes type))) (render-isl-aref (car (relay-reads type)) :genid #'(lambda (x) (intern (nth x *access*))))))
 		  #.(impl-binary :OR "|")
 		  #.(impl-binary :AND "&")
 		  (:WHERE

--- a/source/ajit/graph.lisp
+++ b/source/ajit/graph.lisp
@@ -75,6 +75,8 @@
 				(expr-aref arg typ)))		    
 			else
 			  collect (expr-const arg))))
+    (when (eql (node-type node) :INDEX-COMPONENTS)
+      (return-from create-expr-from-air (make-expr :INDEX-COMPONENTS (first parents) (cdr parents))))
     (assert (<= (length parents) 3) () "~a cannot be grouped to multi expr! (too many arguments)" node)
     (case (node-type node)
       (:WHERE (make-expr (node-type node) (first parents) (second parents) (third parents)))

--- a/source/ajit/graph.lisp
+++ b/source/ajit/graph.lisp
@@ -80,9 +80,7 @@
       (:WHERE (make-expr (node-type node) (first parents) (second parents) (third parents)))
       (:LT    (make-expr (node-type node) (second parents) (third parents)))
       (:NEQ   (make-expr (node-type node) (second parents) (third parents)))
-      (:Load (if (numberp (getattr node :value))
-		 (expr-const (getattr node :value))
-		 (expr-aref (getattr node :value) (car (relay-writes (read-type-relay node))))))
+      (:Load (expr-const (getattr node :value)))
       (:Cast (expr-cast (second parents) (getattr node :dtype)))
       (otherwise (make-expr (node-type node) (first parents) (second parents))))))
 

--- a/source/ajit/graph.lisp
+++ b/source/ajit/graph.lisp
@@ -80,7 +80,9 @@
       (:WHERE (make-expr (node-type node) (first parents) (second parents) (third parents)))
       (:LT    (make-expr (node-type node) (second parents) (third parents)))
       (:NEQ   (make-expr (node-type node) (second parents) (third parents)))
-      (:Load (expr-const (getattr node :value)))
+      (:Load (if (numberp (getattr node :value))
+		 (expr-const (getattr node :value))
+		 (expr-aref (getattr node :value) (car (relay-writes (read-type-relay node))))))
       (:Cast (expr-cast (second parents) (getattr node :dtype)))
       (otherwise (make-expr (node-type node) (first parents) (second parents))))))
 

--- a/source/ajit/helpers.lisp
+++ b/source/ajit/helpers.lisp
@@ -100,7 +100,7 @@
    (null (getattr node :_tmp))
    (not (= (getattr node :nrank) 0))))
 
-(defun purge-allocations (poly pipeline dynamic-shapes &aux (allocs nil) (types (poly-vm-io-types poly)))
+(defun purge-allocations (poly pipeline dynamic-shapes &aux (allocs nil) (types (poly-vm-io-types poly)) (outputs (poly-vm-outputs poly)))
   (declare (type polyhedral poly) (type hash-table pipeline))
   (maphash
    #'(lambda (k graph)
@@ -109,7 +109,7 @@
 	     (loop for node in (graph-nodes graph)
 		   if (alloc-args-p node)
 		     do (push node allocs)
-		   else
+		   else unless (and (eql (node-type node) :Allocate) (find (car (node-writes node)) outputs))
 		     collect node)))
    pipeline)
   (let ((tensor-allocs (remove-duplicates allocs :key (compose #'car #'node-writes)))

--- a/source/ajit/helpers.lisp
+++ b/source/ajit/helpers.lisp
@@ -71,14 +71,16 @@
 
 (defun reveal-buffer (object)
   "Extracts the initial-value from the nested buffer/fake-array"
-  (declare (type (or buffer fakearray integer-t) object))
-  (if (buffer-p object)
-      (if (fakearray-p (buffer-value object))
-	  (fakearray-initial-element (buffer-value object))
-	  (buffer-value object))
-      (if (fakearray-p object)
-	  (fakearray-initial-element object)
-	  object)))
+  (declare (type (or buffer fakearray integer-t string) object))
+  (if (stringp object)
+      object
+      (if (buffer-p object)
+	  (if (fakearray-p (buffer-value object))
+	      (fakearray-initial-element (buffer-value object))
+	      (buffer-value object))
+	  (if (fakearray-p object)
+	      (fakearray-initial-element object)
+	      object))))
 
 (defmacro with-inlined-foreign-funcall-mode (&body body)
   "Enables %\"foreign-name\":return-dtype &rest args syntax under the body execution"

--- a/source/ajit/helpers.lisp
+++ b/source/ajit/helpers.lisp
@@ -115,11 +115,7 @@
   (let ((tensor-allocs (remove-duplicates allocs :key (compose #'car #'node-writes)))
 	(shapes (map 'list
 		     #'(lambda (x &aux (type (or (gethash x types) (error "~a is not inferred by poly-vm-io-types" x))))
-			 (let ((out (%alloc 0 nil nil :dtype (buffer-dtype (car (relay-writes type))) :id x)))
-			   (when (find x (poly-vm-outputs poly))
-			     ;; x should be a pointer to obtain the result
-			     (setf (getattr out :_pointer) t))
-			   out))
+			 (%alloc 0 nil nil :dtype (buffer-dtype (car (relay-writes type))) :id x))
 		     dynamic-shapes)))
     (remove-duplicates `(,@shapes ,@tensor-allocs) :key (compose #'car #'node-writes))))
 

--- a/source/ajit/helpers.lisp
+++ b/source/ajit/helpers.lisp
@@ -110,14 +110,20 @@
 		   if (alloc-args-p node)
 		     do (push node allocs)
 		   else unless (and (eql (node-type node) :Allocate) (find (car (node-writes node)) outputs))
-		     collect node)))
+			  collect node)))
    pipeline)
-  (let ((tensor-allocs (remove-duplicates allocs :key (compose #'car #'node-writes)))
-	(shapes (map 'list
-		     #'(lambda (x &aux (type (or (gethash x types) (error "~a is not inferred by poly-vm-io-types" x))))
-			 (%alloc 0 nil nil :dtype (buffer-dtype (car (relay-writes type))) :id x))
-		     dynamic-shapes)))
-    (remove-duplicates `(,@shapes ,@tensor-allocs) :key (compose #'car #'node-writes))))
+  (let* ((tensor-allocs (remove-duplicates allocs :key (compose #'car #'node-writes)))
+ 	 (shapes (map 'list
+		      #'(lambda (x &aux (type (or (gethash x types) (error "~a is not inferred by poly-vm-io-types" x))))
+			  (%alloc 0 nil nil :dtype (buffer-dtype (car (relay-writes type))) :id x))
+		      dynamic-shapes))
+	 (allocs (remove-duplicates `(,@shapes ,@tensor-allocs) :key (compose #'car #'node-writes))))
+    (loop for alloc in allocs
+	  if (find (car (node-writes alloc)) (poly-vm-inputs poly)) ;; Shapes are not pointer
+	    do (setf (getattr alloc :_pointer) nil)
+	  else
+	    do (setf (getattr alloc :_pointer) t))
+    allocs))
 
 (defun get-subgraph-recursively (node graph dynamic-shapes dtype)
   (declare (type node node) (type graph graph))

--- a/source/ajit/polyhedral.lisp
+++ b/source/ajit/polyhedral.lisp
@@ -6,9 +6,10 @@
 ;; TODO: Symbolic Model Scheduling
 (defstruct (Polyhedral
 	    (:conc-name poly-)
-	    (:constructor make-polyhedral (avm pipeline domain read write schedule vm-inputs)))
+	    (:constructor make-polyhedral (avm pipeline domain read write schedule vm-inputs vm-outputs)))
   (avm avm :type avm)
   (vm-inputs vm-inputs :type list)
+  (vm-outputs vm-outputs :type list)
   (pipeline pipeline :type hash-table)
   ;; constraints
   (domain domain :type string)

--- a/source/ajit/polyhedral.lisp
+++ b/source/ajit/polyhedral.lisp
@@ -21,6 +21,11 @@
   (write-ptr (isl-union-map-read-from-str write) :type isl-obj)
   (schedule schedule :type isl-obj))
 
+(defun poly/io-scalar-p (poly x)
+  (let ((type (gethash x (poly-vm-io-types poly))))
+    (when (null type) (error "~a is not input/output" type))
+    (= (buffer-nrank (car (relay-writes type))) 0)))
+
 (defun finalize-polyhedral (polyhedral &aux (schedule (poly-schedule polyhedral)))
   (declare (type polyhedral polyhedral))
   (macrolet ((set-option (name level)

--- a/source/ajit/polyhedral.lisp
+++ b/source/ajit/polyhedral.lisp
@@ -10,6 +10,7 @@
   (avm avm :type avm)
   (vm-inputs vm-inputs :type list)
   (vm-outputs vm-outputs :type list)
+  (vm-io-types (infer-vm-io-types avm `(,@vm-inputs ,@vm-outputs)) :type hash-table)
   (pipeline pipeline :type hash-table)
   ;; constraints
   (domain domain :type string)

--- a/source/ajit/renderer.lisp
+++ b/source/ajit/renderer.lisp
@@ -15,7 +15,7 @@
 function void (args) { body };
 ```"))
 
-(defgeneric %render-body (lang kernel-lang jit-graph polyhedral indent)
+(defgeneric %render-body (lang kernel-lang jit-graph polyhedral indent allocs)
   (:documentation
    "IRs used in the jit-graph:
 (TODO: Docs)

--- a/source/ajit/scheduler.lisp
+++ b/source/ajit/scheduler.lisp
@@ -475,7 +475,8 @@ Options:
   (let* ((extracted-schedule (finalize-schedule polyhedron))
 	 (rendering-graph (create-rendering-graph polyhedron extracted-schedule))
 	 (_      (apply-memory-planner refcount polyhedron avm rendering-graph))
-	 (allocs (purge-allocations polyhedron (poly-pipeline polyhedron) (append (poly-vm-inputs polyhedron) (poly-vm-outputs polyhedron))))
+	 (outputs (loop for o in (poly-vm-outputs polyhedron) if (poly/io-scalar-p polyhedron o) collect o))
+	 (allocs (purge-allocations polyhedron (poly-pipeline polyhedron) (append (poly-vm-inputs polyhedron) outputs)))
 	 ;; Start Rendering
 	 (body     (%render-body backend backend rendering-graph polyhedron 1))
 	 (function (%render-function backend avm allocs body))

--- a/source/ajit/scheduler.lisp
+++ b/source/ajit/scheduler.lisp
@@ -478,7 +478,7 @@ Options:
 	 (outputs (loop for o in (poly-vm-outputs polyhedron) if (poly/io-scalar-p polyhedron o) collect o))
 	 (allocs (purge-allocations polyhedron (poly-pipeline polyhedron) (append (poly-vm-inputs polyhedron) outputs)))
 	 ;; Start Rendering
-	 (body     (%render-body backend backend rendering-graph polyhedron 1))
+	 (body     (%render-body backend backend rendering-graph polyhedron 1 allocs))
 	 (function (%render-function backend avm allocs body))
 	 (function (%render-program-toplevel backend function))
 	 (fcaller-body (%render-function-caller backend avm allocs))

--- a/source/ajit/scheduler.lisp
+++ b/source/ajit/scheduler.lisp
@@ -198,7 +198,10 @@ A[stride1 * view_info1 * index_component_0 + bias1 + stride2 * view_info2 * inde
 	     (when (and (not (numberp upfrom)) access-rep) (setf upfrom 1))
 	     (if broadcast-p
 		 (format nil "~a" upfrom)
-		 (format nil "~a(~a~a)"
+		 ;; とにかくこの箇所を修正する for index accessing and proper scheduling
+		 ;; stride * by * gid + upfrom * by * loop-size
+		 ;; symbolicが動かないのは簡略化のせいでは？ setf 1
+		 (format nil "~a~a~a"
 			 (if (eql by 1)
 			     (if (and (numberp stride) (= stride 1))
 				 ""
@@ -209,7 +212,9 @@ A[stride1 * view_info1 * index_component_0 + bias1 + stride2 * view_info2 * inde
 				     (format nil "~a*" (* stride by))
 				     (format nil "~a*~a*" by stride))))
 			 gid
-			 (if (eql upfrom 0) "" (format nil "+~a" upfrom)))))
+			 (if (eql upfrom 0)
+			     ""
+			     (format nil "+(~a*~a)" upfrom stride)))))
 	   "+")))))
 
 (defun render-domain (pipeline &key (depends-on nil))

--- a/source/ajit/scheduler.lisp
+++ b/source/ajit/scheduler.lisp
@@ -193,14 +193,12 @@ A[stride1 * view_info1 * index_component_0 + bias1 + stride2 * view_info2 * inde
 	  (list
 	   (progn
 	     ;; Ugly solution... should be temporary...
+	     ;; [TODO] FIX This (when `if` is scheduled by ISL, there's no way to update the index) to make mean working
 	     (when (and (not (numberp stride)) access-rep) (setf stride 1))
 	     (when (and (not (numberp by)) access-rep) (setf by 2))
 	     (when (and (not (numberp upfrom)) access-rep) (setf upfrom 1))
 	     (if broadcast-p
 		 (format nil "~a" upfrom)
-		 ;; とにかくこの箇所を修正する for index accessing and proper scheduling
-		 ;; stride * by * gid + upfrom * by * loop-size
-		 ;; symbolicが動かないのは簡略化のせいでは？ setf 1
 		 (format nil "~a~a~a"
 			 (if (eql by 1)
 			     (if (and (numberp stride) (= stride 1))

--- a/source/ajit/scheduler.lisp
+++ b/source/ajit/scheduler.lisp
@@ -393,7 +393,7 @@ Pipeline: A hash-table where keys and values are: {T_ID[Fixnum] -> Scheduled_Sub
 	    (format t "== [Initial Scheduling domain (=domain)] ======")
 	    (format t "~%~a~%" schedule)
 	    (isl-schedule-dump schedule))
-	  (values (make-polyhedral avm pipeline domain read-access write-access schedule vm-inputs) seen))))))
+	  (values (make-polyhedral avm pipeline domain read-access write-access schedule (append vm-inputs recursive-top-ids)) seen))))))
 ;; polyhedral compilation to determine the parallelization strategy
 ;; If we do; compile from avm into ISL, optimizng
 ;; This is the toplevel of all optimization stuff
@@ -474,7 +474,7 @@ Options:
   ;; Preprocessing
   (let* ((extracted-schedule (finalize-schedule polyhedron))
 	 (rendering-graph (create-rendering-graph polyhedron extracted-schedule))
-	 (_ (apply-memory-planner refcount (poly-pipeline polyhedron) avm rendering-graph))
+	 (_ (apply-memory-planner refcount polyhedron avm rendering-graph))
 	 (allocs (purge-allocations (poly-pipeline polyhedron) (poly-vm-inputs polyhedron)))
 	 ;; Start Rendering
 	 (body (%render-body backend backend rendering-graph polyhedron 1))

--- a/source/ajit/scheduler.lisp
+++ b/source/ajit/scheduler.lisp
@@ -474,16 +474,15 @@ Options:
   ;; Preprocessing
   (let* ((extracted-schedule (finalize-schedule polyhedron))
 	 (rendering-graph (create-rendering-graph polyhedron extracted-schedule))
-	 (_ (apply-memory-planner refcount polyhedron avm rendering-graph))
-	 (allocs (purge-allocations (poly-pipeline polyhedron) (append (poly-vm-inputs polyhedron) (poly-vm-outputs polyhedron))))
+	 (_      (apply-memory-planner refcount polyhedron avm rendering-graph))
+	 (allocs (purge-allocations polyhedron (poly-pipeline polyhedron) (append (poly-vm-inputs polyhedron) (poly-vm-outputs polyhedron))))
 	 ;; Start Rendering
-	 (body (%render-body backend backend rendering-graph polyhedron 1))
+	 (body     (%render-body backend backend rendering-graph polyhedron 1))
 	 (function (%render-function backend avm allocs body))
 	 (function (%render-program-toplevel backend function))
 	 (fcaller-body (%render-function-caller backend avm allocs))
 	 (f (compile nil fcaller-body)))
     (declare (ignore _))
-    (assert (functionp f) () "%render-function-caller should return a function!")
     (when (>= debug 1) (format t "Compiled[~a]:~%~a" name function))
     (%render-compile backend avm allocs function)
     (let* ((subgraph

--- a/source/ajit/simplifiers.lisp
+++ b/source/ajit/simplifiers.lisp
@@ -259,20 +259,17 @@
 	    (avm-bw-outputs avm) (map 'list #'newid (avm-bw-outputs avm))
 	    ;; vm-inputs are fixed (they are dynamic shapes)
 	    (poly-vm-outputs polyhedron) (map 'list #'newid (poly-vm-outputs polyhedron)))
-      
-      (let ((new-id2tensor (make-hash-table)))
-	(maphash
-	 #'(lambda (k v)
-	     (setf (gethash (newid k) new-id2tensor) v))
-	 (avm-id2tensor avm))
-	(setf (avm-id2tensor avm) new-id2tensor))
-      
-      (let ((new-variables (make-hash-table)))
-	(maphash
-	 #'(lambda (k v)
-	     (setf (gethash (newid k) new-variables) v))
-	 (avm-variables avm))
-	(setf (avm-variables avm) new-variables)))))
+
+      (macrolet ((renew (accessor)
+		   `(let ((new-table (make-hash-table)))
+		      (maphash
+		       #'(lambda (k v)
+			   (setf (gethash (newid k) new-table) v))
+		       ,accessor)
+		      (setf ,accessor new-table))))
+	(renew (avm-id2tensor avm))
+	(renew (poly-vm-io-types polyhedron))
+	(renew (avm-variables avm))))))
 
 (defun apply-multiexpr-grouping (pipeline)
   "Group several computation into a single :EXPR Node to simplify.

--- a/source/ajit/simplifiers.lisp
+++ b/source/ajit/simplifiers.lisp
@@ -187,7 +187,10 @@
 		 (loop for node in (graph-nodes (gethash time pipeline))
 		       if (eql (node-type node) :Allocate)
 			 collect (car (node-writes node)))))
-	 (allocated-items (append allocated-items (poly-vm-inputs polyhedron) (poly-vm-outputs polyhedron))))
+	 (allocated-items (append allocated-items
+				  (poly-vm-inputs polyhedron)
+				  (loop for o in (poly-vm-outputs polyhedron)
+					if (poly/io-scalar-p polyhedron o) collect o))))
     (labels ((inplace-p (node time)
 	       ;; (in-place-p . intersects-with-current-pipeline?)
 	       (when (eql (node-type node) :Allocate) (return-from inplace-p (cons t t)))

--- a/source/ajit/simplifiers.lisp
+++ b/source/ajit/simplifiers.lisp
@@ -187,7 +187,7 @@
 		 (loop for node in (graph-nodes (gethash time pipeline))
 		       if (eql (node-type node) :Allocate)
 			 collect (car (node-writes node)))))
-	 (allocated-items (append allocated-items (poly-vm-inputs polyhedron))))
+	 (allocated-items (append allocated-items (poly-vm-inputs polyhedron) (poly-vm-outputs polyhedron))))
     (labels ((inplace-p (node time)
 	       ;; (in-place-p . intersects-with-current-pipeline?)
 	       (when (eql (node-type node) :Allocate) (return-from inplace-p (cons t t)))
@@ -257,7 +257,8 @@
       
       (setf (avm-fw-outputs avm) (map 'list #'newid (avm-fw-outputs avm))
 	    (avm-bw-outputs avm) (map 'list #'newid (avm-bw-outputs avm))
-	    (poly-vm-inputs polyhedron) (map 'list #'newid (poly-vm-inputs polyhedron)))
+	    ;; vm-inputs are fixed (they are dynamic shapes)
+	    (poly-vm-outputs polyhedron) (map 'list #'newid (poly-vm-outputs polyhedron)))
       
       (let ((new-id2tensor (make-hash-table)))
 	(maphash

--- a/source/apis/initializers.lisp
+++ b/source/apis/initializers.lisp
@@ -70,7 +70,7 @@
 	(num (reduce #'%mul base-shape))
 	(size (%ceiling nil (%idiv nil num (%iconst 2))))
 	(counts1 (%make-tensor (list size) :dtype :uint32))
-	(counts1 (%add (%index-components counts1) (%broadcast-to (list size) rng-counter :dtype :uint32 :skip-load t)))
+	(counts1 (%add (%index-components counts1 base-shape) (%broadcast-to (list size) rng-counter :dtype :uint32 :skip-load t)))
 	(counts2 (%add counts1 size))
 	(counts1_64 (%make-tensor (list size) :dtype :uint64))
 	(counts2_64 (%make-tensor (list size) :dtype :uint64))
@@ -119,7 +119,7 @@
 (defmethod lower ((op Linspace) &rest inputs)
   (multiple-value-bind (a b x) (apply #'values inputs)
     (with-context
-      (i (%index-components x))
+      (i (%index-components x (%shape (shape (third (func-variables op))))))
       (t1 (%mul i a))
       (t2 (%add t1 b))
       (c  (%store x t2)))))

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -329,11 +329,13 @@
 	      &key
 		(jit (= 1 (ctx:getenv :JIT)))
 		(name (intern (symbol-name (gensym "MAIN")) "KEYWORD"))
+		(static-gensym (= 1 (ctx:getenv :STATIC_GENSYM)))
 		(simplifiers *external-simplifiers*)) ;; TODO disassemble options etc
   "Compiles the (Abstract) tensor"
   (when (tensor-p tensors)
     (setf tensors (list tensors)))
   (let ((avm (%compile-toplevel tensors :name name :external-simplifiers simplifiers)))
+    (when static-gensym (caten/ajit:apply-static-gensym avm))
     (if jit (caten/ajit:jit avm) avm)))
 
 (defun avm/sync-tensors (avm)

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -329,13 +329,11 @@
 	      &key
 		(jit (= 1 (ctx:getenv :JIT)))
 		(name (intern (symbol-name (gensym "MAIN")) "KEYWORD"))
-		(static-gensym (= 1 (ctx:getenv :STATIC_GENSYM)))
 		(simplifiers *external-simplifiers*)) ;; TODO disassemble options etc
   "Compiles the (Abstract) tensor"
   (when (tensor-p tensors)
     (setf tensors (list tensors)))
   (let ((avm (%compile-toplevel tensors :name name :external-simplifiers simplifiers)))
-    (when static-gensym (caten/ajit:apply-static-gensym avm))
     (if jit (caten/ajit:jit avm) avm)))
 
 (defun avm/sync-tensors (avm)

--- a/source/apis/test-suites.lisp
+++ b/source/apis/test-suites.lisp
@@ -523,4 +523,4 @@
 
 (deftest call-aot
   (let ((a (with-device :lisp (proceed (ax+b `(3 3) 1 1)))) (b (with-device :lisp (proceed (ax+b `(3 3) 1 1)))))
-    (every #'= #(2 4 6 8 10 12 14 16 18) (elements (axpy :float32 a b 9 0 9 1 0 9 1)))))
+    (ok (every #'= #(2 4 6 8 10 12 14 16 18) (elements (axpy :float32 a b 9 0 9 1 0 9 1))))))

--- a/source/avm/test-suites.lisp
+++ b/source/avm/test-suites.lisp
@@ -15,7 +15,7 @@
 (defun %arange (shape a b &key (dtype :float32) (order :row))
   (with-asm
     (m (%make-tensor shape :dtype dtype :order order))
-    (i (%index-components m))
+    (i (%index-components m (%shape shape)))
     (alpha (%load (%salloc :dtype dtype) a))
     (beta  (%load (%salloc :dtype dtype) b))
     ;; a = alpha * i + b
@@ -102,7 +102,7 @@
 		 ,ans
 		 (with-context
 		   (a (%make-tensor ',shape :order ,order))
-		   (b (%index-components a))))))
+		   (b (%index-components a (%shape ',shape)))))))
     (testwhen :row (3 3) #(0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0))
     (testwhen :column (3 3) #(0.0 3.0 6.0 1.0 4.0 7.0 2.0 5.0 8.0))
     (testwhen :row (3 4 5) #(0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0 12.0 13.0 14.0


### PR DESCRIPTION
- [x] Support the graph whose outputs are scalar (use scalar pointers)
- [x] BugFix: (!view xxx `(-1 1 -1)) in JIT (fix render-isl-aref)
- [x] Fix: Index-Component for column major
- Fix: val_xxx is undeclared
    - [x] Solved for forward mode
    - [ ] Solved for the backward mode (needs some refactor)
        - Enumerate all save-for-backward existing in the graph before start compilation
        - Move on another PR
- [x] (fconst 'a) should be inferred to :float, not :uint32_t
- [ ] Improve memory-planner to fuse/remove extra allocation (as well as the backward mode!)
- [ ] Refactor the renderer; To render an instruction, we only need either of `%render-expr` or `%render-node`. (REMOVE MULTIEXPR=1)
- [ ] Fix segv; make ISL gc-reachable
- [ ] all unittest for recently added computations
(After this PR merged, let's start working on OpenCL/METAL Backends or improving the polyhedral compiler to support OMP, vectorization, 4x4 accumulation for gemm, etc)