### PR TITLE
Patch for CCL and ECL

### DIFF
--- a/.github/workflows/tests_on_push.yml
+++ b/.github/workflows/tests_on_push.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        lisp: [sbcl-bin/2.4.0, ecl] # Caten should work on the latest sbcl; but (ql:quickload :dissect) which rove depends on, fails with > sbcl-bin/2.4.2
+        lisp: [sbcl-bin/2.4.0, ccl-bin/1.12.2, ecl] # Caten should work on the latest sbcl; but (ql:quickload :dissect) which rove depends on, fails with > sbcl-bin/2.4.2
         os: [ubuntu-latest]
         target:
         - normal
@@ -38,11 +38,13 @@ jobs:
       - name: Check $PATH
         run: echo $PATH
       - name: (Lisp) JIT=0 AVM=LISP rove caten.asd
+        if: ${{ matrix.lisp != 'ecl' }}
         run: |
           ros config set dynamic-space-size 4gb
           ros -e '(ql:register-local-projects)' -q
           CI=1 JIT=0 AVM=LISP rove caten.asd
       - name: (Clang JIT) JIT=1 JIT_BACKEND=CLANG rove caten.asd
+        if: ${{ matrix.lisp != 'ccl-bin/1.12.2' }}
         run: |
           ros config set dynamic-space-size 4gb
           ros -e '(ql:register-local-projects)' -q

--- a/.github/workflows/tests_on_push.yml
+++ b/.github/workflows/tests_on_push.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        lisp: [sbcl-bin/2.4.0, ccl-bin/1.12.2, ecl] # Caten should work on the latest sbcl; but (ql:quickload :dissect) which rove depends on, fails with > sbcl-bin/2.4.2
+        lisp: [sbcl-bin/2.4.0, ecl] # Caten should work on the latest sbcl; but (ql:quickload :dissect) which rove depends on, fails with > sbcl-bin/2.4.2
         os: [ubuntu-latest]
         target:
         - normal

--- a/.github/workflows/tests_on_push.yml
+++ b/.github/workflows/tests_on_push.yml
@@ -38,13 +38,12 @@ jobs:
       - name: Check $PATH
         run: echo $PATH
       - name: (Lisp) JIT=0 AVM=LISP rove caten.asd
-        if: ${{ matrix.lisp != 'ecl' }}
         run: |
           ros config set dynamic-space-size 4gb
           ros -e '(ql:register-local-projects)' -q
           CI=1 JIT=0 AVM=LISP rove caten.asd
       - name: (Clang JIT) JIT=1 JIT_BACKEND=CLANG rove caten.asd
-        if: ${{ matrix.lisp != 'ccl-bin/1.12.2' }}
+        if: ${{ matrix.lisp == 'sbcl-bin/2.4.0' }}
         run: |
           ros config set dynamic-space-size 4gb
           ros -e '(ql:register-local-projects)' -q

--- a/source/ajit/helpers.lisp
+++ b/source/ajit/helpers.lisp
@@ -6,6 +6,16 @@
 (defmacro range (from below &optional (by 1))
   `(loop for i from ,from below ,below by ,by collect i))
 
+(defun maphash1 (function hash-table)
+  "Equivalent to the maphash, but the order in which keys are called is sorted.
+Since the order in which functions are executed are not ANSI Portable. For scheduler related algorithm, this function
+should be used instead"
+  (declare (type function function) (type hash-table hash-table))
+  (let ((keys (hash-table-keys hash-table)))
+    (assert (every #'numberp keys))
+    (loop for key in (sort keys #'<)
+	  do (funcall function key (gethash key hash-table)))))
+
 (defun render-list (list) (apply #'concatenate 'string (butlast (loop for n in list append (list (format nil "~a" n) ", ")))))
 (defun render-schedule (sched)
   (let* ((graph (apply #'make-graph (si-nodes sched)))

--- a/source/ajit/scheduler.lisp
+++ b/source/ajit/scheduler.lisp
@@ -256,7 +256,7 @@ Pipeline: A hash-table where keys and values are: {T_ID[Fixnum] -> Scheduled_Sub
   (with-output-to-string (out)
     ;; renders depends-on
     (format out "[~(~a~)] -> {~%" (render-list depends-on))
-    (maphash
+    (maphash1
      #'(lambda (timestamp subgraph)
 	 (let* ((loop-factors (graph->loop-factors subgraph))
 		(constraints
@@ -290,7 +290,7 @@ Pipeline: A hash-table where keys and values are: {T_ID[Fixnum] -> Scheduled_Sub
 	   (type hash-table pipeline))
   (with-output-to-string (out)
     (format out "[~(~a~)] -> {~%" (render-list depends-on))
-    (maphash
+    (maphash1
      #'(lambda (timestamp subgraph)
 	 (let* ((lf (graph->loop-factors subgraph))
 		(occur-from
@@ -339,7 +339,7 @@ Pipeline: A hash-table where keys and values are: {T_ID[Fixnum] -> Scheduled_Sub
 
 (defun isl-initial-schedule (pipeline &key depends-on)
   (let ((schedule :nothing))
-    (maphash
+    (maphash1
      #'(lambda (ts graph)
 	 (let* ((loop-factors (graph->loop-factors graph))
 		(constraints


### PR DESCRIPTION
- [ ] Passing all tests in ECL/CCL
  - [x] Introduced maphash1 instead of maphash, enabling proper scheduling
  - [ ] Clasp Support? (which brings us LLVM/C++ Interop)
- [ ] Use lparallel for ulp related tests.
- [ ] Relax the limit of ulp tests (from 1.0ulp to 1e-3 for all x)
- [ ] make all tests green
- [ ] when some tests failing, ci should become red
- [ ] making isl objects gc-safe