### PR TITLE
Post-MultiExpr Fusion in the equivalent domain

### DIFF
--- a/source/ajit/isl-ast-helpers.lisp
+++ b/source/ajit/isl-ast-helpers.lisp
@@ -33,7 +33,7 @@
 
 (defmethod print-object ((expr Expr) stream)
   (if (eql (expr-op expr) :Aref)
-      (format stream "aref{~(~a~):~(~a~)}" (expr-x expr) (buffer-dtype (expr-y expr)))
+      (format stream "~(~a~)[~(~a~)]" (expr-x expr) (render-aref (default-device :clang) (expr-y expr)))
       (if (expr-z expr)
 	  (format stream "~(~a~)(~(~a~), ~(~a~), ~(~a~))" (expr-op expr) (expr-x expr) (expr-y expr) (expr-z expr))
 	  (if (expr-y expr)

--- a/source/ajit/render-graph.lisp
+++ b/source/ajit/render-graph.lisp
@@ -79,6 +79,13 @@ Loop is either of :Global or :Local
 	  new
 	  (simplify-rendering-nodes new)))))
 
+(defmethod simplify-render-graph ((group Group))
+  (setf (graph-nodes (group-render-graph group))
+        (simplify-rendering-nodes
+         (simplifier/remove-empty-funcall
+          (graph-nodes (group-render-graph group))
+          (poly-pipeline (group-polyhedron group))))))
+
 (defun simplifier/remove-empty-if (nodes &aux (removed nil))
   (loop for node in nodes
 	for nth upfrom 0
@@ -97,4 +104,9 @@ Loop is either of :Global or :Local
 		(eql (node-type (nth (1+ nth) nodes)) :ENDFOR))
 	  do (push (node-id (nth (1+ nth) nodes)) removed)
 	else unless (find (node-id node) removed)
-	       collect node))
+               collect node))
+
+(defun simplifier/remove-empty-funcall (nodes pipeline)
+  (loop for node in nodes
+        unless (and (eql (node-type node) :FUNCALL) (null (graph-nodes (gethash (getattr node :idx) pipeline))))
+          collect node))

--- a/source/ajit/test-suites.lisp
+++ b/source/ajit/test-suites.lisp
@@ -48,8 +48,8 @@
       (check-kernels 1 (caten (caten/nn:!softmax (ax+b `(10 10) 1 1))))
       (check-kernels 1 (caten (caten/nn:!softmax (ax+b `(a b) 1 1))))
       (check-kernels 1 (caten (!softmax (!softmax (!softmax (ax+b `(10 10) 1 1))))))
-      (check-kernels 3 (caten (!cos (!sin (!padding (make-tensor `(10 10) :initial-element 2.0) `((2 2) (2 2)) :value 0.0)))))
-      (check-kernels 1 (caten (!sin (!matmul (make-tensor `(10 20)) (make-tensor `(20 30)))))) ;; [TODO] make 1 kernels.
+      (check-kernels 2 (caten (!cos (!sin (!padding (make-tensor `(10 10) :initial-element 2.0) `((2 2) (2 2)) :value 0.0)))))
+      (check-kernels 1 (caten (!sin (!matmul (make-tensor `(10 20)) (make-tensor `(20 30))))))
       (check-kernels 2 (caten (!matmul (make-tensor `(128 32)) (!matmul (make-tensor `(32 64)) (make-tensor `(64 128))))))
       ;; TODO (!sin (!matmul a b b c))
       ;;(check-kernels 1 (caten (!add (!view (make-tensor `(n)) `(froma toa bya)) (!view (make-tensor `(n)) `(fromb tob byb)))))

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -302,7 +302,7 @@ When moving a node in T0 into T1, the operation is represented as:
    (expr-eq (getattr node1 :by) (getattr node2 :by))))
 
 (defun extend-expr (graph group target-node leaf-node leaf-id nodeid->pipeline)
-  "Merges leaf-node to the target-node by grafting them"
+  "Merges leaf-node to the target-node by grafting them."
   (declare (type Node target-node leaf-node))
   (expr-graft-after (getattr target-node :EXPR) leaf-id (getattr leaf-node :expr))
   (remnode graph (node-id leaf-node))
@@ -492,12 +492,13 @@ Note: This is a trade-off: it minimizes the number of DRAM accesses, which gener
 			  (dolist (node (graph-nodes (gethash (getattr node :idx) pipeline)))
 			    (when (eql (node-type node) :EXPR)
 			      ,form)))))
-      ;; Globalize Index-Components (its 100% no benefits of making a cache)
+      
       ;; Reading render-node by render-node
       ;; t=0 | FOR idx = ...    (skip)
       ;; t=1 | FUNCALL = ...    (apply simplifier)
       ;; t=2 | ENDFOR idx = ... (skip)
       ;;       ...
+      ;; Applying render-graph level simplifiers, all of these are optional.
       (do-funcall (expr-apply-post-multiexpr-in-domain group graph node funcall->domain nodeid->pipeline))
       (do-funcall (expr-apply-post-multiexpr-in-equivalent-domain group graph node funcall->domain nodeid->pipeline))
 

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -300,7 +300,26 @@ When moving a node in T0 into T1, the operation is represented as:
    (expr-eq (getattr node1 :upfrom) (getattr node2 :upfrom))
    (expr-eq (getattr node1 :below) (getattr node2 :below))
    (expr-eq (getattr node1 :by) (getattr node2 :by))))
+
+(defun extend-expr (target-node leaf-node)
+  (declare (type Node target-node leaf-node))
   
+  )
+
+(defun serialize-graph (graph1 graph2)
+  "
+Relocated GRAPH1 in advance of GRAPH2
+for (...)
+  GRAPH1
+for (...)
+  GRAPH2
+->
+for (...)
+  GRAPH1
+  GRAPH2"
+  (declare (type Graph graph1 graph2))
+
+  )
 
 ;; [TODO]
 ;; - Randn < 2 Kernels (Fuse Scalar Kernels and vector parts)
@@ -541,7 +560,7 @@ Note: This is a trade-off: it minimizes the number of DRAM accesses, which gener
       ;; t=2 | ENDFOR idx = ... (skip)
       ;;       ...
       (do-funcall (expr-apply-post-multiexpr-in-domain group graph node funcall->domain nodeid->pipeline))
-      (do-funcall (expr-apply-post-multiexpr-in-equivalent-domain group graph node funcall->domain nodeid->pipeline))
+      ;; (do-funcall (expr-apply-post-multiexpr-in-equivalent-domain group graph node funcall->domain nodeid->pipeline))
       ;; (do-funcall (expr-apply-post-multiexpr-subdomain group graph node funcall->domain nodeid->pipeline))
       ;; (do-funcall (expr-apply-index-component-globalize group graph node funcall->domain nodeid->pipeline))
       ;; (do-funcall (expr-apply-post-multiexpr-in-subdomain group graph node funcall->domain nodeid->pipeline))

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -303,7 +303,7 @@ When moving a node in T0 into T1, the operation is represented as:
 	(buffer-views buffer) (and (buffer-views buffer) (every #'identity (buffer-views buffer)) (permute-list permute (buffer-views buffer))))
   buffer)
 
-;; [TODO]
+;; [TODO] .
 (defmethod expr-apply-index-component-globalize ((group group) (graph graph) (node node) funcall->domain nodeid->pipeline)
   "Propagate Index-Components"
   ;; not working

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -508,4 +508,4 @@ Note: This is a trade-off: it minimizes the number of DRAM accesses, which gener
       ;;          |
       ;;        Matrix
       ;; 3. In-Place Embedding, By propagating index-components and boolean parts
-      )))
+      (simplify-render-graph group))))

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -305,12 +305,12 @@ When moving a node in T0 into T1, the operation is represented as:
 ;; [TODO]
 ;; - Randn < 2 Kernels (Fuse Scalar Kernels and vector parts)
 (defmethod expr-apply-post-multiexpr-in-domain ((group group) (graph graph) (node node) funcall->domain nodeid->pipeline)
+  "Post MultiExpr Fusion in the same domain."
   (flet ((get-domain-from-funcall (node)
            (gethash (or (gethash (node-id node) nodeid->pipeline) (error "~a is not defined in nodeid->pipeline." node)) funcall->domain))
          (domain-eq (dom1 dom2)
            (and (= (length dom1) (length dom2))
-                ;; (every #'eql (map 'list #'node-id dom1) (map 'list #'node-id dom2))
-                (every #'domain-equal dom1 dom2)))
+                (every #'eql (map 'list #'node-id dom1) (map 'list #'node-id dom2))))
          (no-across-domain-dep-p (id)
            ;; Returns T if A and B are connected one-by-one:
            ;; A -> B
@@ -359,6 +359,73 @@ When moving a node in T0 into T1, the operation is represented as:
                              if (or (= nth 0) (and (not (eql r read)) (find r used)))
                                collect r))))))
 
+(defmethod expr-apply-post-multiexpr-in-equivalent-domain ((group group) (graph graph) (node node) funcall->domain nodeid->pipeline)
+  (flet ((get-domain-from-funcall (node)
+           (gethash (or (gethash (node-id node) nodeid->pipeline) (error "~a is not defined in nodeid->pipeline." node)) funcall->domain))
+         (domain-eq (dom1 dom2)
+           (and (= (length dom1) (length dom2))
+                ;; Conflicts with expr-apply-post-multiexpr-in-equivalent-domain
+                (not (every #'eql (map 'list #'node-id dom1) (map 'list #'node-id dom2)))
+                (every #'domain-equal dom1 dom2)))
+         (node->funcall (node)
+	   (let ((idx (gethash (node-id node) nodeid->pipeline)))
+	     (find idx (graph-nodes (group-render-graph group)) :key #'(lambda (x) (getattr x :idx)))))
+         (no-across-domain-dep-p (id)
+           ;; Returns T if A and B are connected one-by-one:
+           ;; A -> B
+           ;; Otherwise returns nil e.g.:
+           ;; A -> B
+           ;;   -> C
+           (and
+            ;; 
+            (null (find id (group-across-time-deps group)))
+            (= (length (id->users graph id)) 1))))
+    (assert (eql :EXPR (node-type node)))
+    ;; FOR
+    ;; T0 | node0 }
+    ;;    | node1 }
+    ;; T1 | node2 }
+    ;;    | node3 } 
+    ;; ENDFOR
+    ;; node0, node1 and node2, node3 are not merged because in the initial schedule, they are assigned to the different loop.
+    ;; After ISL Scheduling, and if they are scheduled to the same loop, merge them with paying attention for the read/write deps.
+    (loop with node-domain = (get-domain-from-funcall node)
+          with node-iteration-space = (node->funcall node)
+          ;; EXPR (out-to, arg1, arg2, ...)
+          ;; node -> arg1 (if arg1 and node has a single path and belongs to the same domain, merge node and arg1)
+          ;;      -> arg2 ...
+          ;;      -> arg3 ...
+          for read in (cdr (node-reads node))
+          for read-node-orig = (id->value graph read)
+          for read-node = (when (and read-node-orig (eql (node-type read-node-orig) :EXPR)) read-node-orig) ;; Only EXPR and EXPR can be merged
+          for read-domain = (and read-node (get-domain-from-funcall read-node))
+          if (and node-domain read-domain (domain-eq node-domain read-domain)
+                  (every #'expr-eq (getattr node-iteration-space :args) (getattr (node->funcall read-node) :args))
+                  ;; Transform and apply? (is it possible?)
+                  (null (getattr read-node :reduction))
+                  (no-across-domain-dep-p read))
+            do ;; (defun merge-exprを追加する
+               ;; merge-expr意外に，グラフのノードを移動する方法を追加しておく (when n.args >= 2)
+               (expr-graft-after (getattr node :EXPR) read (getattr read-node :expr))
+               (remnode graph (node-id read-node))
+               (remnode
+                (gethash (gethash (node-id read-node) nodeid->pipeline) (poly-pipeline (group-polyhedron group)))
+                (node-id read-node))
+               (let ((used (expr-recursive-deps (getattr node :EXPR))))
+                 (setf (relay-reads (read-type-relay node))
+                       (loop for rt in (append (relay-reads (read-type-relay node)) (relay-reads (read-type-relay read-node)))
+                             for r in (append (node-reads node) (node-reads read-node))
+                             for nth upfrom 0
+                             if (or (= nth 0) (and (not (eql r read)) (find r used)))
+                               collect rt)
+                       (node-reads node)
+                       (loop for r in (append (node-reads node) (node-reads read-node))
+                             for nth upfrom 0
+                             if (or (= nth 0) (and (not (eql r read)) (find r used)))
+                               collect r))))))
+;; Merge: Scalar
+;;          |
+;;        Matrix
 (defmethod expr-apply-post-multiexpr-subdomain ((group group) (graph graph) (node node) funcall->domain nodeid->pipeline)
   (assert (eql :EXPR (node-type node)))
   (flet ((get-domain-from-funcall (node)
@@ -474,6 +541,7 @@ Note: This is a trade-off: it minimizes the number of DRAM accesses, which gener
       ;; t=2 | ENDFOR idx = ... (skip)
       ;;       ...
       (do-funcall (expr-apply-post-multiexpr-in-domain group graph node funcall->domain nodeid->pipeline))
+      (do-funcall (expr-apply-post-multiexpr-in-equivalent-domain group graph node funcall->domain nodeid->pipeline))
       ;; (do-funcall (expr-apply-post-multiexpr-subdomain group graph node funcall->domain nodeid->pipeline))
       ;; (do-funcall (expr-apply-index-component-globalize group graph node funcall->domain nodeid->pipeline))
       ;; (do-funcall (expr-apply-post-multiexpr-in-subdomain group graph node funcall->domain nodeid->pipeline))

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -309,7 +309,7 @@ When moving a node in T0 into T1, the operation is represented as:
            (gethash (or (gethash (node-id node) nodeid->pipeline) (error "~a is not defined in nodeid->pipeline." node)) funcall->domain))
          (domain-eq (dom1 dom2)
            (and (= (length dom1) (length dom2))
-                ;;(every #'eql (map 'list #'node-id dom1) (map 'list #'node-id dom2))
+                ;; (every #'eql (map 'list #'node-id dom1) (map 'list #'node-id dom2))
                 (every #'domain-equal dom1 dom2)))
          (no-across-domain-dep-p (id)
            ;; Returns T if A and B are connected one-by-one:

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -560,7 +560,7 @@ Note: This is a trade-off: it minimizes the number of DRAM accesses, which gener
       ;; t=2 | ENDFOR idx = ... (skip)
       ;;       ...
       (do-funcall (expr-apply-post-multiexpr-in-domain group graph node funcall->domain nodeid->pipeline))
-      ;; (do-funcall (expr-apply-post-multiexpr-in-equivalent-domain group graph node funcall->domain nodeid->pipeline))
+      (do-funcall (expr-apply-post-multiexpr-in-equivalent-domain group graph node funcall->domain nodeid->pipeline))
       ;; (do-funcall (expr-apply-post-multiexpr-subdomain group graph node funcall->domain nodeid->pipeline))
       ;; (do-funcall (expr-apply-index-component-globalize group graph node funcall->domain nodeid->pipeline))
       ;; (do-funcall (expr-apply-post-multiexpr-in-subdomain group graph node funcall->domain nodeid->pipeline))

--- a/source/apis/initializers.lisp
+++ b/source/apis/initializers.lisp
@@ -5,7 +5,9 @@
 ;;   it implements PRNG Generator based on threefry2x32.
 ;;   *rng-counter* and *manual-seed* should be depended upon commonly by all graphs.
 ;; ~~ randomness ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-(defun make-rng-counter () (proceed (make-tensor `(1) :dtype :uint32 :id '_rng_counter)))
+(defun make-rng-counter ()
+  (ctx:with-contextvar (:jit 0)
+    (proceed (make-tensor `(1) :dtype :uint32 :id '_rng_counter))))
 (defparameter *manual-seed* 0)
 (defparameter *rng-counter* (make-rng-counter))
 (defun set-manual-seed (&key (seed 0))

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -420,6 +420,8 @@ The iseq obtained by lowering the Module must match the output destination speci
   (when (tensor-p tensors)
     (setf tensors (list tensors)))
   (let ((avm (%compile-toplevel tensors :name name :external-simplifiers simplifiers)))
+    ;; ?
+    (when (= (ctx:getenv :CI) 1) (trivial-garbage:gc))
     (if jit (caten/ajit:jit avm :backend (or *jit-device* (ctx:getenv :jit_backend))) avm)))
 
 (defun avm/sync-tensors (avm)

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -420,8 +420,8 @@ The iseq obtained by lowering the Module must match the output destination speci
   (when (tensor-p tensors)
     (setf tensors (list tensors)))
   (let ((avm (%compile-toplevel tensors :name name :external-simplifiers simplifiers)))
-    ;; ?
-    (when (= (ctx:getenv :CI) 1) (trivial-garbage:gc))
+    ;; FIXME: Since we can't determine when garbage collection (in caten/isl) will occur during testing, we run it every time.
+    (when (and (= (ctx:getenv :JIT) 1) (= (ctx:getenv :CI) 1)) (trivial-garbage:gc))
     (if jit (caten/ajit:jit avm :backend (or *jit-device* (ctx:getenv :jit_backend))) avm)))
 
 (defun avm/sync-tensors (avm)

--- a/source/common/contextvar.lisp
+++ b/source/common/contextvar.lisp
@@ -132,6 +132,9 @@ Usage:
 	 (when (not (typep x '(integer 0 4))) (warn "JIT_DEBUG should be an integer from 0 to 3, got ~a, setting 0" x) (setf x 0))
 	 x)
        "DEBUG-Level during jit-compilation")
+    (:CI
+     0 :int identity
+     "Set 1 if the test is running under Github Actions")
     (:JIT
      0 :int identity
      "Set 1 to use JIT_BACKEND, 0 to use VM_BACKEND")

--- a/source/isl/isl-object.lisp
+++ b/source/isl/isl-object.lisp
@@ -33,8 +33,7 @@ of type OBJECT-NAME."
 (defvar *isl-object-table* (trivial-garbage:make-weak-hash-table :weakness :value))
 (defmacro with-isl-context (&body body)
   "Assumes under the body is a thread-safe"
-  `(let* ((*isl-object-table* (trivial-garbage:make-weak-hash-table :weakness :value))
-	  (*context* (make-context)))
+  `(let* ((*context* (make-context)))
      ,@body))
 
 (defmacro define-isl-object
@@ -74,6 +73,7 @@ of type OBJECT-NAME."
 		 *isl-object-table*
                  (trivial-garbage:finalize (,%%make handle)
                                            (lambda ()
+                                             ;; (format t "Free: [~a] ~a~%" ',name (cffi:pointer-address handle))
 					     (remhash (cffi:pointer-address handle) *isl-object-table*)
 					     (,%free handle))))))))
        ,@(when %copy

--- a/source/nn/activations.lisp
+++ b/source/nn/activations.lisp
@@ -155,7 +155,7 @@
   :lisp  ((model x) (proceed (!log-softmax x)))
   :assert-close ((x y)
 		 (every (~= 1e-6) (elements x) (elements y)))
-  :in-place ((model) (= 2 (n-args `(512 256) model))) ;; [TODO] THIS SHOULD BE IN_PLACE!!
+  :in-place ((model) (= 1 (n-args `(512 256) model)))
   :kernel   ((model) (= 1 (n-kernels model))))
 
 (defun elu-lisp (x &aux (alpha 1.0)) (- (relu-lisp x) (relu-lisp (* alpha (- 1 (exp x))))))


### PR DESCRIPTION
- [x] Post-MultiExpr (Completely Equivalent Domain)
- [ ] Post-MultiExpr (where subdomain is the equivalent)
- [ ] Index-Component-Fusion
- [ ] Add the following transform pattern to EXPR:
- [ ] More Restrict Schedule test in nn or ajit (e.g.: Embedding in one kernel)
- [ ] matmul transpose fusion by multiexpr? (subdomain)
- [x] fix for double free (?) (rng-counter might be related to this)
```
val_445[(_gid0+0)] = (val_456_0^((val_445[(_gid0+0)]*32768)+(uint32_t)((float)val_445[(_gid0+0)]*7.6293945e-6)));
->
float _tmp_0 = val_445[_gid0+0];
val_445[_gid0+0] = (val_456_0^((_tmp_0*32768)+(uint32_t)((float)_tmp_0*7.6293945e-6)));
```
- [x] Fix: 6d transposed matmul scheduler
- [x] randn < 2 kernels including scalar parts
  - [ ] Tests for In-place Embedding, 2 Kernel Randn
  - [ ] Accuracy tests for RMSNorm, Embedding, etc ...

- [ ] Deleting the dead code:
```clang
void main500811_e229_k0(uint32_t* val_400, uint32_t* val_123, uint32_t val_397) {
  (*val_123) = 4;
  (*val_400) = (val_397+(*val_123));
  uint32_t val_124 = (*val_400);
}
```

```

```