### PR TITLE
JIT: Post-MultiExpr Optimization between different iteration spaces (Final)

### DIFF
--- a/source/ajit/backends/clang.lisp
+++ b/source/ajit/backends/clang.lisp
@@ -213,7 +213,7 @@ Compiled with: ~a"
   (declare (type graph jit-graph)
 	   (type polyhedral polyhedral)
 	   (type fixnum indent))
-  (let ((*args* (loop for arg in args if (argument-pointer-p arg) collect (caten/ajit:argument-name arg))))
+  (let ((*args* (loop for arg in args if (argument-pointer-p arg) collect (argument-name arg))))
     (with-output-to-string (out)
       (macrolet ((line (designator &rest args)
 		   `(progn

--- a/source/ajit/isl-ast-helpers.lisp
+++ b/source/ajit/isl-ast-helpers.lisp
@@ -28,8 +28,15 @@
    (expr-eq (expr-x x) (expr-x y))
    (expr-eq (expr-y x) (expr-y y))
    (expr-eq (expr-z x) (expr-z y))))
-
 (defmethod expr-eq ((x t) (y t)) (equal x y))
+
+(defmethod expr-cmp ((f function) (x expr) (y expr))
+  (and
+   (eql (expr-op x) (expr-op y))
+   (expr-cmp f (expr-x x) (expr-x y))
+   (expr-cmp f (expr-y x) (expr-y y))
+   (expr-cmp f (expr-z x) (expr-z y))))
+(defmethod expr-cmp ((f function) (x t) (y t)) (funcall f x y))
 
 (defmethod print-object ((expr Expr) stream)
   (if (eql (expr-op expr) :Aref)

--- a/source/ajit/multiexpr.lisp
+++ b/source/ajit/multiexpr.lisp
@@ -139,7 +139,7 @@
 	       (push obj *aref-list*)))
 	   obj))
     (case (node-type node)
-      (:INDEX-COMPONENTS (make-expr :INDEX-COMPONENTS (use (first parents)) (map 'list #'use (cdr parents))))
+      (:INDEX-COMPONENTS (make-expr :INDEX-COMPONENTS (first parents) (map 'list #'use (cdr parents))))
       (:Cast             (make-cast (use (second parents)) (getattr node :dtype)))
       (:Load             (use (make-const (getattr node :value) (make-const-buffer (buffer-dtype (car (relay-writes (read-type-relay node))))))))
       (:!=               (make-expr :!= (use (second parents)) (use (third parents))))

--- a/source/ajit/multiexpr.lisp
+++ b/source/ajit/multiexpr.lisp
@@ -139,7 +139,7 @@
 	       (push obj *aref-list*)))
 	   obj))
     (case (node-type node)
-      (:INDEX-COMPONENTS (make-expr :INDEX-COMPONENTS (first parents) (map 'list #'use (cdr parents))))
+      (:INDEX-COMPONENTS (make-expr :INDEX-COMPONENTS (use (first parents)) (map 'list #'use (cdr parents))))
       (:Cast             (make-cast (use (second parents)) (getattr node :dtype)))
       (:Load             (use (make-const (getattr node :value) (make-const-buffer (buffer-dtype (car (relay-writes (read-type-relay node))))))))
       (:!=               (make-expr :!= (use (second parents)) (use (third parents))))

--- a/source/ajit/test-suites.lisp
+++ b/source/ajit/test-suites.lisp
@@ -69,9 +69,9 @@
       (check-args 1 `(3 3) (caten (!tan (make-tensor `(3 3)))))
       (check-args 1 `(3 3) (caten (!tan (!tan (!tan (make-tensor `(3 3)))))))
       (check-args 1 `(3 3) (caten (!softmax (make-tensor `(3 3)))))
-      (check-args 1 `(3 3) (caten (!softmax (ax+b `(3 3) 1 1))))
-      (check-args 1 `(3 3) (caten (!softmax (!softmax (ax+b `(3 3) 1 1)))))
-      (check-args 1 `(t t) (caten (!softmax (!softmax (ax+b `(a b) 1 1))))))))
+      (check-args 2 `(3 3) (caten (!softmax (ax+b `(3 3) 1 1))))
+      (check-args 1 `(3 3) (caten (!softmax (!softmax (make-tensor `(3 3))))))
+      (check-args 1 `(t t) (caten (!softmax (!softmax (make-tensor `(a b)))))))))
 
 (deftest matmul-schedule-test
   (with-no-grad
@@ -94,8 +94,7 @@
   (testing "Embedding < 1 Kernels, < 3 Tensors."
     (with-no-grad
       (check-kernels 1 (caten (call (Embedding 100 100) (make-tensor `(100 100)))))
-      ;; [TODO]: Remove Index-Component buffer
-      (check-args 4 t (caten (call (Embedding 100 100) (make-tensor `(100 100))))))))
+      (check-args 3 t (caten (call (Embedding 100 100) (make-tensor `(100 100))))))))
 
 ;;(deftest symbolic-function-args-test
 ;;  (with-no-grad

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -333,7 +333,7 @@ for (...)
 for (...)
   GRAPH1
   GRAPH2"
-  (declare (type Graph graph1 graph2))
+  (declare (type Graph graph1 graph2) (ignore graph1 graph2))
 
   )
 

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -536,15 +536,6 @@ If failed, the function returns a keyword :failed"
                  ;; So it is ok to overwrite its attributes.
                  (assert (eql (node-type read-iteration-space) :FUNCALL))
                  ;; Transforms the iteration space of funcall to fit the destination.
-                 ;;(print "++++++++++")
-                 ;;(print "CANDIDATE FOUND!")
-                 ;;(print node)
-                 ;;(print read-node)
-                 ;;(print "NEW_SPACE")
-                 ;;(print (getattr read-iteration-space :args))
-                 ;;(print "->")
-                 ;;(print (getattr node-iteration-space :args))
-                 ;;(print read-domain) (print node-domain)
                  (let ((new-iteration-space (find-new-iteration-space
                                              read-iteration-space node-iteration-space
                                              read-domain node-domain)))
@@ -552,17 +543,9 @@ If failed, the function returns a keyword :failed"
                      (setf changed-p t)
                      ;; It is required to make new FUNCALL with args are properly shuffed.
                      ;; By finding the equivalent loop bound
-                     ;; Recursivelyに適用できるか？
-                     ;; node->idも更新するhつようがありそう？
-                     ;; ここでSetfしてfuncall->domainを更新する必要がありそう
                      (setf (getattr read-iteration-space :args) new-iteration-space
                            (gethash (gethash (node-id read-node) nodeid->pipeline) funcall->domain) node-domain)
-                     (serialize-graph (group-render-graph group) read-iteration-space node-iteration-space)
-                     ;;(print "Read is transformed into")
-                     ;;(print new-iteration-space)
-                     )))))
-  ;; Recursiveを実装する???
-  ;; Otherwise Index-Component wouldn't be fused in embedding.
+                     (serialize-graph (group-render-graph group) read-iteration-space node-iteration-space))))))
   changed-p)
 
 ;; (defmethod expr-apply-post-multiexpr-wmma-transpose

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -647,7 +647,7 @@ Note: This is a trade-off: it minimizes the number of DRAM accesses, which gener
       ;; Applying render-graph level simplifiers, all of these are optional.
       (do-funcall (expr-apply-post-multiexpr-in-domain group graph node funcall->domain nodeid->pipeline))
       (do-funcall (expr-apply-post-multiexpr-in-equivalent-domain group graph node funcall->domain nodeid->pipeline))
-      ;;(do-funcall (expr-apply-post-multiexpr-subdomain group graph node funcall->domain nodeid->pipeline) :recursively t)
+      (do-funcall (expr-apply-post-multiexpr-subdomain group graph node funcall->domain nodeid->pipeline) :recursively t)
       ;; TODO: Special Simplifier to :type :WMMA
       ;; - [ ] Fix: broadcast-regression-test (when packed=1, they cannot be unrolled, especially when including :INDEX_COMPONENTS)
       ;; - [ ] WMMA+Transpoe Fusion

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -495,6 +495,15 @@ If failed, the function returns a keyword :failed"
                  ;; So it is ok to overwrite its attributes.
                  (assert (eql (node-type read-iteration-space) :FUNCALL))
                  ;; Transforms the iteration space of funcall to fit the destination.
+                 (print "++++++++++")
+                 (print "CANDIDATE FOUND!")
+                 (print node)
+                 (print read-node)
+                 (print "NEW_SPACE")
+                 (print (getattr read-iteration-space :args))
+                 (print "->")
+                 (print (getattr node-iteration-space :args))
+                 (print read-domain) (print node-domain)
                  (let ((new-iteration-space (find-new-iteration-space
                                              read-iteration-space node-iteration-space
                                              read-domain node-domain)))
@@ -502,21 +511,17 @@ If failed, the function returns a keyword :failed"
                      (setf changed-p t)
                      ;; It is required to make new FUNCALL with args are properly shuffed.
                      ;; By finding the equivalent loop bound
-                     ;; T0(0, 0, c0, 0) -> argsで回してT1と比較
                      ;; Recursivelyに適用できるか？
                      ;; node->idも更新するhつようがありそう？
-                     (setf (getattr read-iteration-space :args) new-iteration-space)
+                     ;; ここでSetfしてfuncall->domainを更新する必要がありそう
+                     (setf (getattr read-iteration-space :args) new-iteration-space
+                           (gethash (gethash (node-id read-node) nodeid->pipeline) funcall->domain) node-domain)
                      (serialize-graph (group-render-graph group) read-iteration-space node-iteration-space)
-                     ;;この関数は再起的に適用する必要がある (until gaining no changes)
-                     (print "CANDIDATE FOUND!")
-                     (print node)
-                     (print read-node)
-                     (print "++++++++++")
-                     (print "NEW_SPACE")
+                     (print "Read is transformed into")
                      (print new-iteration-space)
                      )))))
-  ;; Recursiveを実装する時は
-  ;; _relocated_pを全てリセットする関数を適用しないといけない
+  ;; Recursiveを実装する???
+  ;; Otherwise Index-Component wouldn't be fused in embedding.
   changed-p)
 
 ;; (defmethod expr-apply-post-multiexpr-wmma-transpose
@@ -607,6 +612,9 @@ Note: This is a trade-off: it minimizes the number of DRAM accesses, which gener
       (do-funcall (expr-apply-post-multiexpr-in-domain group graph node funcall->domain nodeid->pipeline))
       (do-funcall (expr-apply-post-multiexpr-in-equivalent-domain group graph node funcall->domain nodeid->pipeline))
       (do-funcall (expr-apply-post-multiexpr-subdomain group graph node funcall->domain nodeid->pipeline))
+
+      ;; applying subdomain multipletimes
+      ;; make it valid to call in-domain after ^
       
       ;; TODO: Merge Domain and SubDomain in order to complete following thing:
       ;; 1. Tranpose+Matmul Fusion (< 1 Kernels by propagating transpose)

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -313,7 +313,7 @@ for (...)
               collect node)))
 
 (defmethod expr-apply-post-multiexpr-in-domain ((group group) (graph graph) (node node) funcall->domain nodeid->pipeline)
-  "Post MultiExpr Fusion in the same domain."
+  "Post MultiExpr Fusion Applicable Case 1, FUNCALL belongs to the same loop (compared by node-id)"
   (flet ((get-domain-from-funcall (node)
            (gethash (or (gethash (node-id node) nodeid->pipeline) (error "~a is not defined in nodeid->pipeline." node)) funcall->domain))
          (domain-eq (dom1 dom2)
@@ -352,6 +352,7 @@ for (...)
             do (extend-expr graph group node read-node read nodeid->pipeline))))
 
 (defmethod expr-apply-post-multiexpr-in-equivalent-domain ((group group) (graph graph) (node node) funcall->domain nodeid->pipeline)
+  "Post MultiExpr Fusion Applicable Case 2, FUNCALLs strongly connected, and belongs to the same loop (compared by idx, size, and order.)"
   (flet ((get-domain-from-funcall (node)
            (gethash (or (gethash (node-id node) nodeid->pipeline) (error "~a is not defined in nodeid->pipeline." node)) funcall->domain))
          (domain-eq (dom1 dom2)
@@ -458,6 +459,7 @@ Note: This is a trade-off: it minimizes the number of DRAM accesses, which gener
       ;; Applying render-graph level simplifiers, all of these are optional.
       (do-funcall (expr-apply-post-multiexpr-in-domain group graph node funcall->domain nodeid->pipeline))
       (do-funcall (expr-apply-post-multiexpr-in-equivalent-domain group graph node funcall->domain nodeid->pipeline))
+      
       ;; TODO: Merge Domain and SubDomain in order to complete following thing:
       ;; 1. Tranpose+Matmul Fusion (< 1 Kernels by propagating transpose)
       ;; 2. Randn < 2 Kernels by propagation scalar parts

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -649,21 +649,18 @@ Note: This is a trade-off: it minimizes the number of DRAM accesses, which gener
       (do-funcall (expr-apply-post-multiexpr-in-equivalent-domain group graph node funcall->domain nodeid->pipeline))
       (do-funcall (expr-apply-post-multiexpr-subdomain group graph node funcall->domain nodeid->pipeline) :recursively t)
       ;; TODO: Special Simplifier to :type :WMMA
-      ;; WMMA+Transpoe Fusion
+      ;; - [ ] Fix: broadcast-regression-test (when packed=1, they cannot be unrolled, especially when including :INDEX_COMPONENTS)
+      ;; - [ ] WMMA+Transpoe Fusion
 
-      ;; applying subdomain multipletimes
-      ;; make it valid to call in-domain after ^
-      
       ;; TODO: Merge Domain and SubDomain in order to complete following thing:
       ;; 1. Tranpose+Matmul Fusion (< 1 Kernels by propagating transpose)
-      ;; 2. Randn < 2 Kernels by propagation scalar parts
+      ;; 2. [ ] Randn < 2 Kernels by propagation scalar parts
       ;; Merge: Scalar
       ;;          |
       ;;        Matrix
-      ;; 3. In-Place Embedding, By propagating index-components and boolean parts
+      ;; 3. [x] In-Place Embedding, By propagating index-components and boolean parts
 
       ;; [TODO] Delete following pattern node (after applying memory-planner)
-      ;; A = A; (by !normal (where :mean=0.0, :std=1.0)
-      
+      ;; A = A; (confirmeed by calling !normal (where :mean=0.0, :std=1.0))
       ;; [TODO] Tile/Parallel/Loop Fission Scheduling to the graph applied memory-planner.
       (simplify-render-graph group))))

--- a/source/ajit/transform.lisp
+++ b/source/ajit/transform.lisp
@@ -647,7 +647,7 @@ Note: This is a trade-off: it minimizes the number of DRAM accesses, which gener
       ;; Applying render-graph level simplifiers, all of these are optional.
       (do-funcall (expr-apply-post-multiexpr-in-domain group graph node funcall->domain nodeid->pipeline))
       (do-funcall (expr-apply-post-multiexpr-in-equivalent-domain group graph node funcall->domain nodeid->pipeline))
-      (do-funcall (expr-apply-post-multiexpr-subdomain group graph node funcall->domain nodeid->pipeline) :recursively t)
+      ;;(do-funcall (expr-apply-post-multiexpr-subdomain group graph node funcall->domain nodeid->pipeline) :recursively t)
       ;; TODO: Special Simplifier to :type :WMMA
       ;; - [ ] Fix: broadcast-regression-test (when packed=1, they cannot be unrolled, especially when including :INDEX_COMPONENTS)
       ;; - [ ] WMMA+Transpoe Fusion


### PR DESCRIPTION
- [x] Getting Optimal Embedding Kernel
  - [x] Fix the behaviour by writing tests
- [x] TODO: Index-Component does not take the first argument. (Embedding < 3 Tensors)
- [ ] Getting Optimal Matmul+Transpose Kernel
  - [ ] Tests
- [ ] Getting Optimal threefry2x32/randn Kernrel
  - [ ] Tests
- [x] Post-MultiExpr (where subdomain is the equivalent)
- [x] Index-Component-Fusion (Tested by view)
- [ ] Add the following transform pattern to EXPR:
```
val_445[(_gid0+0)] = (val_456_0^((val_445[(_gid0+0)]*32768)+(uint32_t)((float)val_445[(_gid0+0)]*7.6293945e-6)));
->
float _tmp_0 = val_445[_gid0+0];
val_445[_gid0+0] = (val_456_0^((_tmp_0*32768)+(uint32_t)((float)_tmp_0*7.6293945e-6)));
```
- [x] Fix: 6d transposed matmul scheduler
- [x] randn < 2 kernels including scalar parts
  - [x] Tests for In-place Embedding, 2 Kernel Randn
  - [ ] Accuracy tests for RMSNorm, Embedding, etc ...

- [ ] Deleting the dead code:
```clang
void main500811_e229_k0(uint32_t* val_400, uint32_t* val_123, uint32_t val_397) {
  (*val_123) = 4;
  (*val_400) = (val_397+(*val_123));
  uint32_t val_124 = (*val_400);
}
```

- [ ] More Restrict Schedule test in nn or ajit (e.g.: Embedding in one kernel)