### PR TITLE
Introduce Pointer Address Inference and revisit the semantic of :MOVE

### DIFF
--- a/source/aasm/attrs.lisp
+++ b/source/aasm/attrs.lisp
@@ -16,7 +16,9 @@
    (_output_type :initform nil :initarg :_output_type)
    (declare-type :initarg :declare-type :initform nil)
    (iterations :initarg :iterations :initform nil)
-   (_lowering_history :initform nil :initarg :_lowering_history))
+   (_lowering_history :initform nil :initarg :_lowering_history)
+   (storage-id-src :initform nil :initarg :storage-id-src)
+   (storage-id-dst :initform nil :initarg :storage-id-dst))
   (:documentation "This node is jitable.
 - declare-type[boolean] When this option is set to T, it is necessary to declare the types of the variables included in. e.g.:
 ```
@@ -156,14 +158,12 @@ out <- x ^ y (if integer)
 ```")
 
 (defnode (:BinaryOps :MOVE) (BinaryOps JITAble)
-	 "Moves the second read into the first read, setting the result to first write.
+	 "Moves reads the second `read` tensor and copies the element into the first read. The first `write` represents for the address of the first read.
 ```
 out <- move(x, y)
 where move(x, y) is x = y
 ```
-- _jit_dont_render_me[boolean] (TODO)
-"
-	 :slots ((_jit_dont_render_me :initform nil)))
+")
 
 (defnode (:BinaryOps :MAX) (BinaryOps JITAble)
 	 "Computes the maximum value of two tensors in read, writing the result to the first write.

--- a/source/aasm/attrs.lisp
+++ b/source/aasm/attrs.lisp
@@ -16,9 +16,7 @@
    (_output_type :initform nil :initarg :_output_type)
    (declare-type :initarg :declare-type :initform nil)
    (iterations :initarg :iterations :initform nil)
-   (_lowering_history :initform nil :initarg :_lowering_history)
-   (storage-id-src :initform nil :initarg :storage-id-src)
-   (storage-id-dst :initform nil :initarg :storage-id-dst))
+   (_lowering_history :initform nil :initarg :_lowering_history))
   (:documentation "This node is jitable.
 - declare-type[boolean] When this option is set to T, it is necessary to declare the types of the variables included in. e.g.:
 ```

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -109,9 +109,7 @@
 		   (push final-node (graph-nodes graph))
 		   (session/assign session grad-id final-node))
 		 (let* ((subgrad (session/read session (car rest-grads)))
-			;; [TODO] Remove _jit_dont_render_me option (should only used in: ./ajit/graph.lisp, air->expr)
-			;; JIT do not want to render the ir below.
-			(final-node (make-node :BinaryOps :MOVE (list grad-id) (list final-grad-id (node->id subgrad)) :_jit_dont_render_me t)))
+			(final-node (make-node :BinaryOps :MOVE (list grad-id) (list final-grad-id (node->id subgrad)))))
 		   (push final-node (graph-nodes graph))
 		   (session/assign session grad-id final-node))))))
    (session-grad->grads session)))

--- a/source/codegen/expr-cache.lisp
+++ b/source/codegen/expr-cache.lisp
@@ -14,7 +14,8 @@
    #:stash-expr
    #:restore-expr
    #:expr-cache-reduce-alias
-   #:read-newid))
+   #:read-newid
+   #:read-ptrid))
 
 (in-package :caten/codegen/expr-cache)
 
@@ -24,11 +25,12 @@
   ((cache :type hash-table :initform (make-hash-table :test 'equal) :accessor cache-table)
    (id2expr :type hash-table :initform (make-hash-table :test 'equal) :accessor id2expr-table)
    (global-counter :initform 0 :type fixnum :accessor global-counter)
+   (pointer-map :type hash-table :accessor cache-pointer-map :initarg :pointer-map)
    (global-reduce-alias :type hash-table :initform (make-hash-table :test 'equal) :accessor expr-cache-reduce-alias))
   (:documentation "Creates a cached object for (scalar) EXPR graph."))
 
-(defmacro with-expr-cache (() &body body)
-  `(let ((*expr-cache* (make-instance 'Expr-Cache)))
+(defmacro with-expr-cache ((&key (pointer-map (make-hash-table))) &body body)
+  `(let ((*expr-cache* (make-instance 'Expr-Cache :pointer-map ,pointer-map)))
      ,@body))
 
 (defun expr-id (num) (format nil "_expr_id_~a" num))
@@ -66,3 +68,7 @@
 (defun read-newid (id)
   (assert *expr-cache*)
   (or (gethash id (expr-cache-reduce-alias *expr-cache*)) id))
+
+(defun read-ptrid (id)
+  (assert *expr-cache*)
+  (or (gethash id (cache-pointer-map *expr-cache*)) id))


### PR DESCRIPTION
`:MOVE` is an operation where:
```
A <- MOVE(B, C)
```
Destructivey moves all the visible elements of C into B, the address of `A` is the address of `B` (to keep DAG)

### Changes

- [ ] We need to introduce a pointer address inference to our IR
  - [ ] `JITAble` now have a storage-id-src and storage-id-dst, let's rewrite w/ them.
- [ ] Fix for Padding2D
- [ ] Fix for Backward
- [ ] NO SIDE EFFECTS ON NODE-READS/NODE-WRITES
- [ ] Remove `graph-propagate-reduction`