### PR TITLE
Introduce Pointer Adress to caten/aasm, and revisit the semantic of :MOVE

### DIFF
--- a/source/aasm/attrs.lisp
+++ b/source/aasm/attrs.lisp
@@ -161,9 +161,7 @@ out <- x ^ y (if integer)
 out <- move(x, y)
 where move(x, y) is x = y
 ```
-- _jit_dont_render_me[boolean] (TODO)
-"
-	 :slots ((_jit_dont_render_me :initform nil)))
+")
 
 (defnode (:BinaryOps :MAX) (BinaryOps JITAble)
 	 "Computes the maximum value of two tensors in read, writing the result to the first write.

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -109,9 +109,7 @@
 		   (push final-node (graph-nodes graph))
 		   (session/assign session grad-id final-node))
 		 (let* ((subgrad (session/read session (car rest-grads)))
-			;; [TODO] Remove _jit_dont_render_me option (should only used in: ./ajit/graph.lisp, air->expr)
-			;; JIT do not want to render the ir below.
-			(final-node (make-node :BinaryOps :MOVE (list grad-id) (list final-grad-id (node->id subgrad)) :_jit_dont_render_me t)))
+			(final-node (make-node :BinaryOps :MOVE (list grad-id) (list final-grad-id (node->id subgrad)))))
 		   (push final-node (graph-nodes graph))
 		   (session/assign session grad-id final-node))))))
    (session-grad->grads session)))

--- a/source/codegen/blueprint.lisp
+++ b/source/codegen/blueprint.lisp
@@ -481,11 +481,12 @@ Depends=~a Reduce=~a Users=~a
     (setf (node-reads node) (map 'list #'car read-items)
           (node-writes node) (map 'list #'car write-items)
           seen nil)
-    (labels ((address-of (id)
-               (read-ptrid
-                (if (gethash id rewrite-map)
-                    (address-of (gethash id rewrite-map))
-                    id)))
+    (labels ((reduce-address-of (id)
+               (if (gethash id rewrite-map)
+                   (reduce-address-of (gethash id rewrite-map))
+                   id))
+             (address-of (id)
+               (read-ptrid (reduce-address-of id)))
              (only-unseen (list)
                (loop for l in list
                      for id = (address-of (car l))
@@ -498,8 +499,8 @@ Depends=~a Reduce=~a Users=~a
         (setf
          (getattr node :read-types) (map 'list #'cdr read-items)
          (getattr node :write-types) (map 'list #'cdr write-items)
-         (getattr node :storage-id-src) (map 'list #'car read-items)
-         (getattr node :storage-id-dst) (map 'list #'car write-items))))))
+         (getattr node :storage-id-src) (map 'list (compose #'reduce-address-of #'car) read-items)
+         (getattr node :storage-id-dst) (map 'list (compose #'reduce-address-of #'car) write-items))))))
 
 (defmethod schedule-item-gather-dynamic-shapes ((node Node) base-graph)
   (flet ((is-dynamic-shape-p (val)

--- a/source/codegen/expr-cache.lisp
+++ b/source/codegen/expr-cache.lisp
@@ -14,7 +14,9 @@
    #:stash-expr
    #:restore-expr
    #:expr-cache-reduce-alias
-   #:read-newid))
+   #:cache-pointer-map
+   #:read-newid
+   #:read-ptrid))
 
 (in-package :caten/codegen/expr-cache)
 
@@ -24,11 +26,12 @@
   ((cache :type hash-table :initform (make-hash-table :test 'equal) :accessor cache-table)
    (id2expr :type hash-table :initform (make-hash-table :test 'equal) :accessor id2expr-table)
    (global-counter :initform 0 :type fixnum :accessor global-counter)
+   (pointer-map :type hash-table :accessor cache-pointer-map :initarg :pointer-map)
    (global-reduce-alias :type hash-table :initform (make-hash-table :test 'equal) :accessor expr-cache-reduce-alias))
   (:documentation "Creates a cached object for (scalar) EXPR graph."))
 
-(defmacro with-expr-cache (() &body body)
-  `(let ((*expr-cache* (make-instance 'Expr-Cache)))
+(defmacro with-expr-cache ((&key (pointer-map (make-hash-table))) &body body)
+  `(let ((*expr-cache* (make-instance 'Expr-Cache :pointer-map ,pointer-map)))
      ,@body))
 
 (defun expr-id (num) (format nil "_expr_id_~a" num))
@@ -66,3 +69,7 @@
 (defun read-newid (id)
   (assert *expr-cache*)
   (or (gethash id (expr-cache-reduce-alias *expr-cache*)) id))
+
+(defun read-ptrid (id)
+  (assert *expr-cache*)
+  (or (gethash id (cache-pointer-map *expr-cache*)) id))

--- a/source/codegen/exprify.lisp
+++ b/source/codegen/exprify.lisp
@@ -26,7 +26,9 @@
   (:export
    #:graph-scalarify
    #:graph-exprify
-   #:graph-propagete-reduction))
+   #:graph-propagate-pointer-id-type
+   #:expr-set-iterations
+   #:expr-rewrite-edge-with-pointer-id))
 
 (in-package :caten/codegen/exprify)
 
@@ -316,27 +318,12 @@
         ;; C <- A + B
         ;; =>
         ;; A += B
-        (expr-only-leaf-are-arguments (graph-propagate-reduction (rewriter 0 (length new-bp)) replaceable))))))
+        (rewriter 0 (length new-bp))))))
 
-(defun rewrite-expr-aref (expr replace)
-  (declare (type graph expr))
-  (dolist (n (graph-nodes expr))
-    (if (eql (node-type n) :AREF)
-        (multiple-value-bind (id type is) (funcall replace (car (node-writes n)) (getattr n :buffer) (getattr n :space))
-          (setf (node-writes n) (list id)
-                (getattr n :buffer) type
-                (getattr n :space) is))
-        (setf (node-reads n)
-              (map
-               'list
-               #'(lambda (x)
-                   (let ((id (funcall replace x nil nil)))
-                     (or id x)))
-               (node-reads n))))))
-
-(defmethod graph-propagate-reduction (blueprint replaceable)
+(defun graph-propagate-pointer-id-type (blueprint)
   (assert *expr-cache*)
-  (let ((id->tgt (expr-cache-reduce-alias *expr-cache*))) ;; id -> (list new_id new_type new_is)
+  (let ((rewrite-map (make-hash-table))
+        (id->tgt (expr-cache-reduce-alias *expr-cache*))) ;; id -> (list new_id new_type new_is)
     (loop for bp in blueprint
           if (and (eql (node-type bp) :EXPR) (getattr bp :reduction))
             do (setf (gethash (car (node-writes bp)) id->tgt)
@@ -349,7 +336,9 @@
                (let ((new-id (final-new-id id)))
                  (if (null new-id)
                      (values id type is)
-                     (apply #'values new-id)))))
+                     (progn
+                       (setf (gethash id rewrite-map) (car new-id))
+                       (values id (second new-id) (third new-id)))))))
       (macrolet ((updt (expr &key (reader) (ireader) (treader))
                    `(loop for nth upfrom 0
                           for read in (,reader ,expr)
@@ -366,7 +355,36 @@
                 do (updt bp :reader node-reads :ireader relay-read-iters :treader relay-reads)
                    (updt bp :reader node-writes :ireader relay-write-iters :treader relay-writes)
                    (rewrite-expr-aref (expr-graph (getattr bp :expr)) #'new))
-        (expr-set-iterations blueprint)))))
+        (values (expr-only-leaf-are-arguments blueprint) rewrite-map)))))
+
+(defun rewrite-expr-aref (expr replace)
+  (declare (type graph expr))
+  (dolist (n (graph-nodes expr))
+    (if (eql (node-type n) :AREF)
+        (multiple-value-bind (id type is) (funcall replace (car (node-writes n)) (getattr n :buffer) (getattr n :space))
+          (setf (node-writes n) (list id)
+                (getattr n :buffer) (or type (getattr n :buffer))
+                (getattr n :space) (or is (getattr n :space))))
+        (setf (node-reads n)
+              (map
+               'list
+               #'(lambda (x)
+                   (let ((id (funcall replace x nil nil)))
+                     (or id x)))
+               (node-reads n))))))
+
+(defun expr-rewrite-edge-with-pointer-id (blueprint map)
+  (flet ((newid (id &optional _ __) (declare (ignore _ __)) (or (gethash id map) id)))
+      (macrolet ((updt (expr &key (reader))
+                   `(loop for nth upfrom 0
+                          for read in (,reader ,expr)
+                          if (and read (symbolp read)) do
+                            (setf (nth nth (,reader ,expr)) (newid read)))))
+        (loop for bp in blueprint
+              if (eql (node-type bp) :EXPR) do
+                (updt bp :reader node-reads)
+                (updt bp :reader node-writes)
+                (rewrite-expr-aref (expr-graph (getattr bp :expr)) #'newid)))))
 
 (defun expr-set-iterations (blueprint)
   (loop with gids = nil
@@ -387,3 +405,5 @@
             (when is
               (setf (getattr bp :iterations) (ensure-iteration-space-length is (getattr bp :iterations))))))
   blueprint)
+
+

--- a/source/codegen/jit.lisp
+++ b/source/codegen/jit.lisp
@@ -368,6 +368,8 @@ caten/codegen overview:
                      (format t "Compilation Time : ~A(sec)" (float (/ (- (get-internal-real-time) start) internal-time-units-per-second)))))))
            (graph-nodes schedule-graph)))))
     ;; 10. Running memory-planner, update the storage-id
+    (setf schedule-graph (->graph schedule-graph))
+    (verify-graph schedule-graph)
     (when (>= (ctx:getenv :JIT_DEBUG) 2)
       (fresh-line)
       (print-info "Running the memory planner..."))

--- a/source/codegen/jit.lisp
+++ b/source/codegen/jit.lisp
@@ -136,7 +136,7 @@ caten/codegen overview:
              (append
               (getattr si :storage-id-dst) ;; optimized by memory-planner
               (map 'list #'car (getattr si :dynamic-shapes))
-              (node-reads si))
+              (getattr si :storage-id-src))
              :output-buffer-n (length (node-writes si))
              :kernel-info (make-compiled-kernel-from-si si graph)))
 
@@ -203,7 +203,6 @@ caten/codegen overview:
 
 (defun schedule-graph->vmop (avm graph &aux (map (id->output-map graph)))
   (declare (type Graph graph))
-  (verify-graph graph)
   (let ((nodes) (allocated))
     (flet ((merge-id (id)
              (multiple-value-bind (deps new-seen) (get-subgraph (avm-graph avm) id allocated)
@@ -372,8 +371,6 @@ caten/codegen overview:
     (when (>= (ctx:getenv :JIT_DEBUG) 2)
       (fresh-line)
       (print-info "Running the memory planner..."))
-    (verify-graph schedule-graph)
-    (setf schedule-graph (->graph schedule-graph))
     ;;(run-memory-planner schedule-graph) disable until fixing weirdness in Padding2D/AutoDiff
     (when (>= (ctx:getenv :JIT_DEBUG) 2)
       (fresh-line)

--- a/source/codegen/rewriting-rules.lisp
+++ b/source/codegen/rewriting-rules.lisp
@@ -316,7 +316,7 @@ out[...] = f(*val_1);
   (setf (getattr schedule-item :blueprint)
         (append
          ;; writes
-         (loop for write in (node-writes schedule-item)
+         (loop for write in (getattr schedule-item :storage-id-dst)
                for wt in (getattr schedule-item :write-types)
                for nth upfrom 0
                collect


### PR DESCRIPTION
`:MOVE` is an operation where:
```
A <- MOVE(B, C)
```
Destructivey moves all the visible elements of C into B, the address of `A` is the address of `B` (to keep DAG)

### Changes

- [x] We need to introduce a pointer address inference to our IR
  - [x] `JITAble` now have a storage-id-src and storage-id-dst, let's rewrite w/ them.
  - [x] make an alias for :MOVE
- [x] Fix for Padding2D
- [x] Fix for Backward
- [x] Remove `graph-propagate-reduction`
- [x] Sort the schedule item properly