### PR TITLE
Fix: Scalar mutated by try-insert-node is not a pointer

### DIFF
--- a/source/codegen/blueprint.lisp
+++ b/source/codegen/blueprint.lisp
@@ -420,7 +420,8 @@ The `Blueprint` is a data structure closer to the `Renderer` than AASM, and it i
           (when (and (> nrank 0) (getattr node :reduction :allow-undefined t))
             ;; The node is located out of the loop, scalarize it.
             (setf (iteration-space-strides (car (relay-read-iters (read-type-relay node))))
-                  (loop repeat nrank collect (expr-const 0 :int64)))))
+                  (loop repeat nrank collect (expr-const 0 :int64))))
+          (when (= nrank 0) (setf (getattr node :declare-type) (list t))))
         (return-from try-insert-node
           (if node-reduce-axes
               (values `(,@(reduce-bp ctx (list node) node-reduce-axes (car (node-writes node))) ,@blueprint) t)

--- a/source/codegen/blueprint.lisp
+++ b/source/codegen/blueprint.lisp
@@ -419,6 +419,8 @@ The `Blueprint` is a data structure closer to the `Renderer` than AASM, and it i
         (let ((nrank (buffer-nrank (car (relay-writes (read-type-relay node))))))
           (when (and (> nrank 0) (getattr node :reduction :allow-undefined t))
             ;; The node is located out of the loop, scalarize it.
+            ;; This will mutate constant as a pointer, or pointer as a constant.
+            ;; Running `simplify-pointer-and-constant` and fix them.
             (setf (iteration-space-strides (car (relay-read-iters (read-type-relay node))))
                   (loop repeat nrank collect (expr-const 0 :int64))))
           (when (= nrank 0) (setf (getattr node :declare-type) (list t))))
@@ -532,6 +534,24 @@ Depends=~a Reduce=~a Users=~a
                              collect (cons s caten/aasm:*default-int*))))))
      :key #'car)))
 
+(defun simplify-pointer-and-constant (blueprints)
+  (let ((constants))
+    (loop for bp in blueprints
+          if (and (not (eql (node-class bp) :Render)) (getattr bp :declare-type)) do
+            (push (car (node-writes bp)) constants))
+    (loop for bp in blueprints
+          if (not (eql (node-class bp) :Render)) do
+            (loop for read in (node-reads bp)
+                  for type in (relay-reads (read-type-relay bp))
+                  for is in (relay-read-iters (read-type-relay bp))
+                  for nth upfrom 0
+                  if (and type is (find read constants)) do
+                    (setf (nth nth (relay-reads (read-type-relay bp)))
+                          (let ((buffer (caten/avm:copy-buffer type)))
+                            (setf (buffer-nrank buffer) -1)
+                            buffer))))
+    blueprints))
+
 (defmethod lower-schedule-item ((node Node) (base-graph Graph) (scheduled-graph Graph))
   "Lowers the Schedule-Item into blueprint"
   (assert (eql (node-type node) :Schedule-Item) () "node is not an Schedule-Item, getting ~a" node)
@@ -559,6 +579,7 @@ Depends=~a Reduce=~a Users=~a
       (setf (getattr node :dynamic-shapes) (schedule-item-gather-dynamic-shapes node base-graph))
       ;; Peforming the OpFusion to the lowered blueprint.
       (setf (ctx-blueprint ctx) (simplify-blueprint (ctx-blueprint ctx))
+            (ctx-blueprint ctx) (simplify-pointer-and-constant (ctx-blueprint ctx))
             (ctx-blueprint ctx) (graph-scalarify (ctx-blueprint ctx) node scheduled-graph)
             (ctx-blueprint ctx) (graph-exprify (ctx-blueprint ctx) node scheduled-graph))
       (expr-set-iterations (ctx-blueprint ctx))

--- a/source/codegen/exprify.lisp
+++ b/source/codegen/exprify.lisp
@@ -141,8 +141,8 @@
                       for nth upfrom 0
                       if (and (symbolp w) wt wi (find w replaceable))
                         do (setf (nth nth (relay-writes (read-type-relay b)))
-                                 (rewrite-as-scalar wt wi (reverse suffix)))
-                           (setf (getattr b :declare-type) (list t)
+                                 (rewrite-as-scalar wt wi (reverse suffix))
+                                 (getattr b :declare-type) (list t)
                                  (node-reads node) (remove w (node-reads node)))
                       else if (find w replaceable)
                              do (setf (getattr b :declare-type) (list t))))
@@ -255,9 +255,7 @@
                       (or (null current-pair)
                           (null (intersection (expr-writes current-pair) (apply #'append (map 'list #'expr-writes other-pairs))))))
                      nil))
-               (group->expr-group (group &aux
-                                           (tops (nodes-write-to group))
-                                           (graph (apply #'make-graph group)) (seen nil))
+               (group->expr-group (group &aux (tops (nodes-write-to group)) (graph (apply #'make-graph group)) (seen nil))
                  (setf (graph-outputs graph) tops)
                  (assert (every #'(lambda (x) (eql (node-type x) :EXPR)) group))
                  (labels ((explore (id &aux (node (id->value graph id)))

--- a/source/codegen/exprify.lisp
+++ b/source/codegen/exprify.lisp
@@ -248,10 +248,11 @@
                   if (eql (node-class bp) :Render) collect bp
                     else collect (exprify bp))))
       (labels ((replace-p (id group other-pairs current-pair)
+                 (declare (ignore group))
                  (if (find id replaceable)
                      ;; If the id was used by more than two nodes, split them. (not to introduce the extra computation)
                      (and
-                      (= 1 (count-if #'(lambda (node) (find id (node-reads node))) group))
+                      (= 1 (count-if #'(lambda (node) (find id (node-reads node))) blueprint)) ;; note: blueprint was previously group
                       (or (null current-pair)
                           (null (intersection (expr-writes current-pair) (apply #'append (map 'list #'expr-writes other-pairs))))))
                      nil))

--- a/source/codegen/helpers.lisp
+++ b/source/codegen/helpers.lisp
@@ -11,7 +11,8 @@
    #:simplify-arithmetic-code
    #:simplify-blueprint
    #:->cdtype
-   #:float-type-of))
+   #:float-type-of
+   #:coerce-dtyped-buffer))
 
 (in-package :caten/codegen/helpers)
 
@@ -109,3 +110,12 @@
 
 (defun float-type-of (value)
   (uiop:symbol-call :caten/apis :float-type-of value))
+
+(defun coerce-dtyped-buffer (arg type)
+  (if (caten/avm:buffer-p arg)
+      (if (= (caten/avm:buffer-nrank arg) 0)
+	  (progn
+	    (setf (caten/avm:buffer-value arg) (caten/common.dtype:dtype/cast (caten/avm:buffer-value arg) type))
+	    arg)
+	  arg)
+      (caten/common.dtype:dtype/cast arg type)))

--- a/source/codegen/jit.lisp
+++ b/source/codegen/jit.lisp
@@ -203,11 +203,11 @@ caten/codegen overview:
                       (gethash (car (node-reads v)) table) v))))
     table))
 
-(defun schedule-graph->vmop (avm graph &aux (map (id->output-map graph)))
-  (declare (type Graph graph))
+(defun schedule-graph->vmop (base-graph graph &aux (map (id->output-map graph)))
+  (declare (type Graph graph base-graph))
   (let ((nodes) (allocated))
     (flet ((merge-id (id)
-             (multiple-value-bind (deps new-seen) (get-subgraph (avm-graph avm) id allocated)
+             (multiple-value-bind (deps new-seen) (get-subgraph base-graph id allocated)
                (setf allocated new-seen)
                (dolist (d deps) (push d nodes)))))
       (dolist (node (graph-nodes graph))
@@ -320,7 +320,8 @@ caten/codegen overview:
   ;; 2. Applying JIT Specific Graph Rewriting Rules in advance (e.g.: Propagete Views, Symbol Loads, ...)
   (apply-rewriting-rules avm)
   ;; 3. Running the scheduler
-  (let ((schedule-graph (graph-schedule (avm-graph avm)))
+  (let ((base-graph (apply #'make-graph (map 'list #'copy-node (graph-nodes (avm-graph avm)))))
+        (schedule-graph (graph-schedule (avm-graph avm)))
         ;; 4. Gathering the dynamic shapes used in the graph.
         (symbolics
           (remove-duplicates
@@ -392,7 +393,7 @@ caten/codegen overview:
           (fresh-line)
           (print-info "Compiling ..."))
         (%compile-kernel renderer (graph-nodes schedule-graph) dir)
-        (let ((new-graph (schedule-graph->vmop avm schedule-graph)))
+        (let ((new-graph (schedule-graph->vmop base-graph schedule-graph)))
           (setf (avm-graph avm) new-graph
                 (avm-tape-length avm) (length (graph-nodes new-graph))
                 (avm-pc avm) 0

--- a/source/codegen/jit.lisp
+++ b/source/codegen/jit.lisp
@@ -145,10 +145,9 @@ caten/codegen overview:
              :output-buffer-n (length (node-writes si))
              :kernel-info (make-compiled-kernel-from-si si graph)
              :dtypes
-             (append
-              (map 'list #'buffer-dtype (getattr si :write-types))
-              (loop for i in (getattr si :dynamic-shapes) collect caten/aasm:*default-int*)
-              (map 'list #'buffer-dtype (getattr si :read-types)))))
+             (loop for item in (getattr si :blueprint)
+                   if (eql (node-type item) :DEFINE-GLOBAL)
+                     collect (getattr item :dtype))))
 
 (defmethod %impl (device (op (eql :JIT_KERNEL)) graph node args)
   (let ((info (getattr node :kernel-info))

--- a/source/codegen/scheduler.lisp
+++ b/source/codegen/scheduler.lisp
@@ -195,19 +195,15 @@ Otherwise, the scheduled items are relocated to the compiled avm directly. Speci
           (dolist (v (buffer-views r))
             (when (and v (third v) (symbolp (third v))) ;; v=(upfrom below by broadcast_p)
               (setf no-symbolic-incremental-p nil))))))
-    (let ((jitable (and (every #'jitable-p (group-items group)) (null full-scalar-p))))
-      (when jitable
-        (dolist (item (group-items group))
-          (node-fuse-const-loadp item base-graph)))
-      (make-node :GRAPH :Schedule-Item writes reads :name (make-unique-schedule-name group)
-                 :jitable jitable
-                 :allocate-p (when allocate-p t)
-                 :auto-schedule-p (and no-symbolic-incremental-p (null full-scalar-p))
-                 :storage-id-dst writes
-                 :storage-id-src reads
-                 :rank rank
-                 :items (group-items group)
-                 :items-to-cache (nodes-apply-static-gensym (map 'list #'copy-node (group-items group)))))))
+    (make-node :GRAPH :Schedule-Item writes reads :name (make-unique-schedule-name group)
+               :jitable (and (every #'jitable-p (group-items group)) (null full-scalar-p))
+               :allocate-p (when allocate-p t)
+               :auto-schedule-p (and no-symbolic-incremental-p (null full-scalar-p))
+               :storage-id-dst writes
+               :storage-id-src reads
+               :rank rank
+               :items (group-items group)
+               :items-to-cache (nodes-apply-static-gensym (map 'list #'copy-node (group-items group))))))
 
 (defmethod merge-schedule-items ((si1 Node) (si2 Node) (base-graph Graph))
   (assert (eql (node-type si1) :Schedule-Item))

--- a/source/codegen/scheduler.lisp
+++ b/source/codegen/scheduler.lisp
@@ -50,8 +50,7 @@ One Schedule-Item corresponds to one kernel in GPU. Therefore, in general, the m
    #:ensure-string-as-compilable)
   (:import-from
    #:caten/codegen/rewriting-rules
-   :nodes-apply-static-gensym
-   :node-fuse-const-loadp)
+   :nodes-apply-static-gensym)
   (:export
    #:graph-schedule
    #:*function-name-maxlen*))

--- a/source/test-suite/test-schedule.lisp
+++ b/source/test-suite/test-schedule.lisp
@@ -19,7 +19,7 @@
       (testing "with-no-grad" (with-no-grad (ok (= 1 (n-kernels (op)))))))))
 
 (define-kernel-count-test tril-triu-matmul 1 (caten (!matmul (!tril (make-tensor `(10 1 1 10))) (!triu (make-tensor `(10 1))))))
-(define-kernel-count-test serialize-argmax-single-kernel 1 (!argmax (!matmul (make-tensor `(10 10)) (make-tensor `(10 10)))))
-(define-kernel-count-test serialize-double-reduction-softmax 1 (!add (!softmax (make-tensor `(3 3))) (!softmax (make-tensor `(3 3)))))
+(define-kernel-count-test serialize-argmax-single-kernel 1 (caten (!argmax (!matmul (make-tensor `(10 10)) (make-tensor `(10 10))))))
+(define-kernel-count-test serialize-double-reduction-softmax 1 (caten (!add (!softmax (make-tensor `(3 3))) (!softmax (make-tensor `(3 3))))))
 (define-kernel-count-test sum-after-double-matmul 3 (caten (!sum (!matmul (make-tensor `(10 10)) (!matmul (make-tensor `(10 10)) (make-tensor `(10 10)))))))
 (define-kernel-count-test activation-after-embedding 1 (with-no-grad (caten (!gelu (call (Embedding 10 10) (make-tensor `(b c)))))))


### PR DESCRIPTION
- [ ] Documentation Test should get green

I have found two failing case for symbolic (which would be prepreq for full symbolic transformer)
```
(caten (!sin (make-tensor `(,(!add (make-tensor `(1)) (iconst 'n))))))
(caten (!add (!add (!index-components `(5)) (!add caten/apis::*rng-counter* (!* (iconst 2) (iconst 'n)) :reduce t))
                   (!* (iconst 2) (iconst 'n))))
```