### PR TITLE
not for merge: a place to benchmark iseq.lisp

### DIFF
--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -1,4 +1,9 @@
 (in-package :caten/apis)
+;; Goal:
+;; - Lower them in 1s
+;; - (defparameter *model* (time (Transformer 64 1 72 1e-5 32)))
+;; - (defparameter *transformer* (caten (call *model* (make-tensor `(10 32)) (iconst 3))))
+
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ;; iseq.lisp transforms the graph of Tensor into caten/aasm graph by the following steps:
 ;; 1. (Sort)     Topologically sorting the tensor graph, getting iseq (a list of tensors)

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -225,7 +225,7 @@
 	       ;; n=2 (Simplify)
 	       ;;      ...
                (when dot (->dot graph :title (format nil "lowerer T=~a" n)))
-	       (%lower-modules session graph)
+	       (%lower-modules session graph) ;; For more than 70 layers: Lower them in a 2~3 calls
 	       ;; Func level whole optimization
 	       (dolist (f external-simplifiers) (funcall f graph))))
            (when dot (->dot graph :title "lowerer (final)"))))

--- a/source/apis/tensor.lisp
+++ b/source/apis/tensor.lisp
@@ -180,7 +180,7 @@ View is a tensor which shares the buffer from the original tensor, but having di
 	 #'(lambda (c) (error 'caten-forward-error :op 'make-view-internal :inputs (list base) :c c))))
     (flet ((is-broadcast (x) (and (listp x) (eql (car x) :~))))
       (let* ((views (merge-views base subscripts allow-merge))
-             (size (time (map 'list #'(lambda (x) (if (tensor-p x) (or (try-fold-constant x) x) x)) (map 'list #'vrange-size views))))
+             (size (map 'list #'(lambda (x) (if (tensor-p x) (or (try-fold-constant x) x) x)) (map 'list #'vrange-size views)))
 	     (buff (%internal-make-tensor nil size :dtype dtype :order order :id id :views views))
 	     (broadcast-mode-p (some #'is-broadcast subscripts)))
 	(when broadcast-mode-p


### PR DESCRIPTION
```
  seconds  |     gc     |     consed    |   calls   |  sec/call  |  name  
---------------------------------------------------------------
     3.429 |      0.000 |   813,055,312 |         3 |   1.142962 | CATEN/APIS::%MAKE-GRAPH-FROM-ISEQ
     0.787 |      0.000 |    51,841,040 |       180 |   0.004372 | CATEN/APIS::COMPOSE-VIEWS-FROM-GRAPH
     0.086 |      0.000 |   258,037,248 |     1,794 |   0.000048 | CATEN/APIS::%MAKE-VIEW-FROM-TRACKER
     0.048 |      0.000 |   307,649,328 |    41,485 |   0.000001 | CATEN/APIS::%LOWER-ISEQ
     0.017 |      0.000 |     8,255,856 |    41,530 |   0.000000 | CATEN/APIS::%TPSORT-TENSORS
     0.016 |      0.000 |    30,701,936 |    41,002 |   0.000000 | CATEN/APIS::MAKE-COMPILER-SESSION
     0.011 |      0.000 |     9,236,416 |    15,760 |   0.000001 | CATEN/APIS::%OBTAIN-FOLD-CONSTANT-RESULT
     0.010 |      0.000 |    14,504,352 |   133,276 |   0.000000 | CATEN/APIS::SESSION/ASSIGN
     0.002 |      0.000 |    13,694,336 |   153,541 |   0.000000 | CATEN/APIS::MAKE-AT
     0.001 |      0.000 |     1,179,424 |     1,168 |   0.000001 | CATEN/APIS::TR-APPLY-UPRANK
     0.001 |      0.000 |     4,389,808 |    50,745 |   0.000000 | CATEN/APIS::MAKE-ST
     0.001 |      0.000 |       982,448 |     1,168 |   0.000001 | CATEN/APIS::COMPUTE-NEW-PERMUTE
     0.001 |      0.000 |       392,784 |       480 |   0.000002 | CATEN/APIS::SYMB
```

- [ ] Break into small PRs
`iseq.lisp` is slow, because of two independent reasons:
- [ ] lower-all is slow (No need to run constant-folding each time the module was lowered, introduce rewrites in addition to external-simplifiers)
- [ ] Some of node creation is ridiculously slow.
  - [ ] One of them is `!view`
    - [ ] `ViewRange`: `from/to/by/size` is a fixnum, not a tensor
    - [ ] Rather, remove `try-fold-constant`. Once simplified by the make-viewrange, that's enoguh
    - [ ] simplifier will never running against the big graph, but small graph by small graph