### PR TITLE
Refactor: fold-constant without recursive function call

### DIFF
--- a/source/aasm/constant-folding.lisp
+++ b/source/aasm/constant-folding.lisp
@@ -2,13 +2,13 @@
 
 (defpattern number (x) `(guard ,x (numberp ,x)))
 (defpattern boolean (x) `(guard ,x (typep ,x 'boolean)))
-
+;; [todo] remove
 (defnode (:Tmp :_TmpScalarConst) () "" :slots ((dtype)))
 (defnode (:Tmp :_TmpScalarBool) () "" :slots ((value)))
 (defnode (:Tmp :_TmpPurged) () "")
 
-(defun reinitialize-tensor (graph id node)
-  (declare (type graph graph))
+(defun reinitialize-tensor (graph node &aux (id (car (node-writes node))))
+  (declare (type graph graph) (optimize (speed 3)))
   (multiple-value-bind (nrank shape stride dtype views)
       (infer-tensor-info graph id)
     ;; [TODO] Fix why shape infer fails
@@ -18,14 +18,111 @@
       (setf shape (map 'list #'->find shape)
 	    stride (map 'list #'->find stride)))
     (let ((viewed (every #'identity views)))
-      (if (= nrank 0)
+      (if (= (the fixnum nrank) 0)
 	  (with-context-nodes (m1 (%salloc :dtype dtype :id id)))
 	  (with-context-nodes
 	    (m1 (%alloc nrank shape stride :dtype dtype :id (if viewed (gensym "TID") (node->id node))))
-	    ;; [TODO] Test against viewed outputs
 	    (m2 (if viewed (%view m1 shape (nth 0 views) (nth 1 views) (nth 2 views) (nth 3 views) stride :id (node->id node)) m1)))))))
 
-;; Folds against scalar values
+(defpattern Const (x dtype) `(<Rule> :Load ((:Allocate () :nrank 0 :dtype ,dtype)) :value (number ,x)))
+(defpattern Var (x dtype) `(<Rule> :Load ((:Allocate () :nrank 0 :dtype ,dtype)) :value ,x))
+(defun Const (x dtype) (with-context-nodes (_ (%load (%salloc :dtype dtype) x))))
+(defpattern Bool (x) `(<Rule> :Load ((:Allocate () :nrank 0 :dtype :bool)) :value (boolean ,x)))
+(defpattern Cast (x dtype) `(<Rule> :Cast ((:Allocate () :nrank 0 :dtype ,dtype) (Const ,x))))
+
+(declaim (inline scalar-p))
+(defun scalar-p (id graph)
+  (declare (type graph graph) (optimize (speed 3)))
+  (let* ((load (id->value id graph))
+         (alloc (and load (id->value (car (node-reads load)) graph))))
+    (and load alloc (eql (node-type load) :LOAD) (eql (node-type alloc) :Allocate)
+         (= (the fixnum (getattr alloc :nrank)) 0) (numberp (getattr load :value)))))
+
+(declaim (inline sfold-index-components sfold-allocate sfold-view))
+(defun sfold-index-components (ss node graph)
+  (declare (type list ss) (type node node) (type graph graph)
+           (optimize (speed 3)))
+  (when ss
+    (let* ((ss-nodes (map 'list #'(lambda (x) (id->value graph x)) ss))
+	   (new-shape (loop for ss-node in (cdr ss-nodes)
+			    for ss-val  in (cdr ss)
+			    if (and ss-node (scalar-p ss-val graph))
+			      collect (car (node-reads ss-node))
+			    else
+			      collect ss-val)))
+      (unless (equal new-shape (cdr ss))
+        (list
+	 (make-node
+          :Indexing :INDEX-COMPONENTS
+          (node-writes node) `(,(car ss) ,@new-shape)))))))
+
+(defun sfold-allocate (ss node graph nrank dtype from)
+  (declare (type list ss) (type node node) (type graph graph) (optimize (speed 3)))
+  (when ss
+    (let* ((ss-nodes (map 'list #'(lambda (x) (id->value graph x)) ss))
+	   (new-shape (loop for ss-node in ss-nodes
+			    for ss-val  in ss
+				if (and ss-node (scalar-p ss-val graph))
+				  collect (car (node-reads ss-node))
+				else
+				  collect ss-val)))
+      (unless (equal new-shape ss)
+        (list
+	 (make-node
+          :Buffer :Allocate
+          (node-writes node) new-shape
+          :nrank nrank :dtype dtype :from from))))))
+
+(defun sfold-view (ss node graph nrank broadcast permute)
+  (declare (type list ss) (type node node) (type graph graph) (optimize (speed 3)))
+  (when ss
+    (let* ((ss-nodes (map 'list #'(lambda (x) (id->value graph x)) ss))
+	   (new-views (loop for ss-node in ss-nodes
+			    for ss-val  in ss
+			    if (and ss-node (scalar-p ss-val graph))
+			      collect (car (node-reads ss-node))
+			    else
+			      collect ss-val)))
+      (when (symbolp (car new-views))
+	(unless (equal new-views ss)
+          (list
+	   (make-node
+	    :Buffer :View
+	    (node-writes node) new-views
+	    :nrank nrank :broadcast broadcast :permute permute)))))))
+
+(defsimplifier
+    (apply-fold-constant :speed 1)
+    ((:Add ((Const x dtype) (Const y _))) -> (Const (+ x y) dtype))
+    ((:Mul ((Const x dtype) (Const y _))) -> (Const (* x y) dtype))
+    ((:Neg ((Const x dtype))) -> (Const (- x) dtype))
+    ((:Recip ((Const x dtype))) -> (Const (/ x) dtype))
+    ((:GCD ((Const x dtype) (Const y _))) -> (Const (gcd x y) dtype))
+    ((:< (_ (Const x _) (Const y _))) -> (Const (< x y) :bool))
+    ((:!= (_ (Const x _) (Const y _))) -> (Const (not (= x y)) :bool))
+    ((:MAX ((Const x dtype) (Const y _))) -> (Const (max x y) dtype))
+    ((:NOT ((Bool x))) -> (Const (not x) :bool))
+    ((:AND ((Bool x) (Bool y))) -> (Const (and x y) :bool))
+    ((:OR ((Bool x) (Bool y))) -> (Const (or x y) :bool))
+    ((:WHERE ((Bool x) (Const y dtype) (Const z _))) -> (Const (if x y z) dtype))
+    ;; 0 * x
+    ((:Mul (_ (Var (= 0) _))) -> ((node graph) (reinitialize-tensor graph node)))
+    ((:Mul ((var (= 0) _) _)) -> ((node graph) (reinitialize-tensor graph node)))
+    ;; 1 * x
+    ((:Mul (x (Var (= 1) _))) -> x)
+    ((:Mul ((var (= 1) _) x)) -> x)
+    ;; 0 + x
+    ((:Add (x (Var (= 0) _))) -> x)
+    ((:Add ((Var (= 0) _) x)) -> x)
+
+    ((:INDEX-COMPONENTS (~ ss)) -> ((node graph) (sfold-index-components ss node graph)))
+    ((:Allocate (~ ss) :nrank (guard nrank (> 0)) :dtype dtype :from from)
+     ->
+     ((node graph) (sfold-allocate ss node graph nrank dtype from)))
+    ((:View (~ ss) :broadcast broadcast :nrank nrank :permute permute)
+     ->
+     ((node graph) (sfold-view ss node graph nrank broadcast permute))))
+    
 (defsimplifier
     (%0_fuse_load_alloc)
     ((:Load ((:Allocate () :nrank 0 :dtype dtype)) :value (number x)) -> (:_TmpScalarConst (x) :dtype dtype))
@@ -50,8 +147,8 @@
     ((:WHERE ((:_TmpScalarBool () :value x) (:_TmpScalarConst (y) :dtype dtype) (:_TmpScalarConst (z))))
      ->
      (:_TmpScalarConst ((if x y z)) :dtype dtype))     
-    ((:Mul (_ (:_TmpScalarConst ((= 0))))) -> ((node graph) (reinitialize-tensor graph (car (node-writes node)) node)))
-    ((:Mul ((:_TmpScalarConst ((= 0))) _)) -> ((node graph) (reinitialize-tensor graph (car (node-writes node)) node)))
+    ((:Mul (_ (:_TmpScalarConst ((= 0))))) -> ((node graph) (reinitialize-tensor graph node)))
+    ((:Mul ((:_TmpScalarConst ((= 0))) _)) -> ((node graph) (reinitialize-tensor graph node)))
     ((:Mul (x (:_TmpScalarConst ((= 1))))) -> (:_TmpPurged (x)))
     ((:Mul ((:_TmpScalarConst ((= 1))) x)) -> (:_TmpPurged (x)))
     ((:Add (x (:_TmpScalarConst ((= 0))))) -> (:_TmpPurged (x)))

--- a/source/aasm/constant-folding.lisp
+++ b/source/aasm/constant-folding.lisp
@@ -117,13 +117,11 @@
     ((:AND ((Bool x) (Bool y))) -> (Const (and x y) :bool))
     ((:OR ((Bool x) (Bool y))) -> (Const (or x y) :bool))
     ((:WHERE ((Bool x) (Const y dtype) (Const z _))) -> (Const (if x y z) dtype))
-    ;; 0 * x
+    ((:Recip ((Var (= 1) dtype))) -> (Const 1 dtype))
     ((:Mul (_ (Var (= 0) _))) -> ((node graph) (reinitialize-tensor graph node)))
     ((:Mul ((var (= 0) _) _)) -> ((node graph) (reinitialize-tensor graph node)))
-    ;; 1 * x
     ((:Mul (x (Var (= 1) _))) -> x)
     ((:Mul ((var (= 1) _) x)) -> x)
-    ;; 0 + x
     ((:Add (x (Var (= 0) _))) -> x)
     ((:Add ((Var (= 0) _) x)) -> x))
 

--- a/source/aasm/constant-folding.lisp
+++ b/source/aasm/constant-folding.lisp
@@ -36,6 +36,8 @@
 (defun Const (x dtype) (with-context-nodes (_ (%load (%salloc :dtype dtype) x))))
 (defpattern Bool (x) `(<Rule> :Load ((:Allocate () :nrank 0 :dtype :bool)) :value (boolean ,x)))
 (defpattern Cast (x dtype) `(<Rule> :Cast ((:Allocate () :nrank 0 :dtype ,dtype) (Const ,x))))
+(defun Purged (node x)
+  (make-node :Buffer :Store (node-writes node) (list (car (node-writes node)) x)))
 
 (declaim (inline scalar-p))
 (defun scalar-p (id graph)
@@ -119,9 +121,9 @@
     ((:WHERE ((Bool x) (Const y dtype) (Const z _))) -> (Const (if x y z) dtype))
     ((:Recip ((Var (= 1) dtype))) -> (Const 1 dtype))
     ((:Mul (_ (Var (= 0) _))) -> ((node graph) (reinitialize-tensor graph node)))
-    ((:Mul ((var (= 0) _) _)) -> ((node graph) (reinitialize-tensor graph node)))
+    ((:Mul ((Var (= 0) _) _)) -> ((node graph) (reinitialize-tensor graph node)))
     ((:Mul (x (Var (= 1) _))) -> x)
-    ((:Mul ((var (= 1) _) x)) -> x)
+    ((:Mul ((Var (= 1) _) x)) -> x)
     ((:Add (x (Var (= 0) _))) -> x)
     ((:Add ((Var (= 0) _) x)) -> x))
 

--- a/source/air/package.lisp
+++ b/source/air/package.lisp
@@ -6,7 +6,6 @@
    #:node-id #:node-type #:node-writes
    #:node-reads #:node-attr #:print-node #:get-output-to)
   (:export #:make-node #:copy-node)
-  (:export #:lower #:mutate)
   (:export #:Graph #:FastGraph #:make-graph #:copy-graph #:graph-p #:graph-seen #:graph-outputs #:Graph-nodes #:id->value #:id->users #:remnode #:verify-graph
 	   #:insert-nodes #:->graph #:->fast-graph #:%graph-nodes-table #:graph-weakly-connected-p)
   (:export #:getattrs #:getattr #:remattr)

--- a/source/air/package.lisp
+++ b/source/air/package.lisp
@@ -10,6 +10,6 @@
   (:export #:Graph #:FastGraph #:make-graph #:copy-graph #:graph-p #:graph-seen #:graph-outputs #:Graph-nodes #:id->value #:id->users #:remnode #:verify-graph
 	   #:insert-nodes #:->graph #:->fast-graph #:%graph-nodes-table #:graph-weakly-connected-p)
   (:export #:getattrs #:getattr #:remattr)
-  (:export #:defsimplifier)
+  (:export #:defsimplifier #:<Node>)
   (:export #:Attribute #:defnode #:debug/render-defined-nodes #:debug/attrs-by-module #:node-build-documentation-by-class #:verify-args #:dump-into-list)
   (:export #:->dot))

--- a/source/air/package.lisp
+++ b/source/air/package.lisp
@@ -10,6 +10,6 @@
   (:export #:Graph #:FastGraph #:make-graph #:copy-graph #:graph-p #:graph-seen #:graph-outputs #:Graph-nodes #:id->value #:id->users #:remnode #:verify-graph
 	   #:insert-nodes #:->graph #:->fast-graph #:%graph-nodes-table #:graph-weakly-connected-p)
   (:export #:getattrs #:getattr #:remattr)
-  (:export #:defsimplifier #:<Node>)
+  (:export #:defsimplifier #:<Rule>)
   (:export #:Attribute #:defnode #:debug/render-defined-nodes #:debug/attrs-by-module #:node-build-documentation-by-class #:verify-args #:dump-into-list)
   (:export #:->dot))

--- a/source/air/pattern-matcher.lisp
+++ b/source/air/pattern-matcher.lisp
@@ -76,10 +76,7 @@
 (defparameter *matched-bind* nil "a temporary place to store matched nodes during simplifying")
 (defvar *node-top* nil)
 (defvar *graph-bind* nil)
-(defpattern <Node> (&rest form)
-  `(and
-    (satisfies (lambda (x) (declare (ignore x)) (setf *matched-bind* nil) t))
-    ,(find/replace-rules form '*graph-bind*)))
+(defpattern <Rule> (&rest form) (find/replace-rules form '*graph-bind*))
 
 (defmacro defsimplifier ((name &key (speed 3)) &rest rules)
   "

--- a/source/air/pattern-matcher.lisp
+++ b/source/air/pattern-matcher.lisp
@@ -56,8 +56,7 @@
     (match rule
       ((list from (symbol-eq "->") to)
        `((and
-          ;; [TODO] This is slow: <> *matched-bind* nil is ok.
-	  (satisfies (lambda (x) (declare (ignore x)) (setf *matched-bind* nil) t))
+	  (<> *matched-bind* nil)
 	  ,(find/replace-rules from graph-bind))
          (values
 	  ,@(match to

--- a/source/air/pattern-matcher.lisp
+++ b/source/air/pattern-matcher.lisp
@@ -40,31 +40,43 @@
 	     `(%Node ,type ,args ,attrs))))
       ((type list) (map 'list #'replace-form rules))
       (_ rules))))
+;; [TODO] node-class => Classを検索する方がいい
+(defun parse-to-pattern (bind rule)
+  (flet ((r (r) (parse-to-pattern bind r)))
+    (match rule
+      ((<>Node type reads attrs)
+       `(make-node (node-class ,bind) ,type (list (gensym)) (list ,@(map 'list #'r reads)) ,@attrs))
+      (_ rule))))
 
 (defun parse-rule (rule bind graph-bind)
   (declare (type list rule))
-  (match rule
-    ((list from (symbol-eq "->") to)
-     `((and
-	(satisfies (lambda (x) (declare (ignore x)) (setf *matched-bind* nil) t))
-	,(find/replace-rules from graph-bind))
-       (values
-	,@(match to
-	    ((<>Node type reads attrs)
-	     `((list (make-node (node-class ,bind) ,type (node-writes ,bind) (list ,@reads) ,@attrs))))
-	    ((list* (list node graph) body)
-	     `((let ((,node ,bind)
-		     (,graph ,graph-bind))
-		 (declare (ignorable ,node ,graph))
-		 ,@body)))
-	    (_
-	     (error "Replace case must be one of:
-    - (:Type (Args) attrs)
-    - ((node graph) body)")))
-	*matched-bind*)))
-    (_ (error "Follow this notation: (From_Pattern) -> (To_Pattern).~%~a" rule))))
+  (flet ((r (r) (parse-to-pattern bind r)))
+    (match rule
+      ((list from (symbol-eq "->") to)
+       `((and
+	  (satisfies (lambda (x) (declare (ignore x)) (setf *matched-bind* nil) t))
+	  ,(find/replace-rules from graph-bind))
+         (values
+	  ,@(match to
+	      ((<>Node type reads attrs)
+	       `((list (make-node (node-class ,bind) ,type (node-writes ,bind) (list ,@(map 'list #'r reads)) ,@attrs))))
+	      ((list* (list node graph) body)
+	       `((let ((,node ,bind)
+		       (,graph ,graph-bind))
+		   (declare (ignorable ,node ,graph))
+		   ,@body)))
+	      (_ `((progn ,to))))
+	  *matched-bind*)))
+      (_ (error "Follow this notation: (From_Pattern) -> (To_Pattern).~%~a" rule)))))
 
 (defparameter *matched-bind* nil "a temporary place to store matched nodes during simplifying")
+(defvar *node-top* nil)
+(defvar *graph-bind* nil)
+(defpattern <Node> (&rest form)
+  `(and
+    (satisfies (lambda (x) (declare (ignore x)) (setf *matched-bind* nil) t))
+    ,(find/replace-rules form '*graph-bind*)))
+
 (defmacro defsimplifier ((name &key (speed 3)) &rest rules)
   "
 ```
@@ -84,71 +96,72 @@ The `graph` is a graph to simplify. The `no-verify` is a flag to skip the verifi
 
 (See also: `./source/aasm/constant-folding.lisp`)
 "
-  (with-gensyms (graph simplifier-bind apply-bind1 apply-bind2 node-top count-bind fast-graph-p seen changed-p)
-    `(defun ,name (,graph &key (no-verify nil) (return-changed-p nil) &aux (,fast-graph-p (typep ,graph 'FastGraph)) (,seen nil) (,changed-p nil))
-       (declare (type graph ,graph)
-		(type boolean no-verify return-changed-p ,fast-graph-p ,changed-p)
-		(type list ,seen)
-		(optimize (speed ,speed)))
-       (unless ,fast-graph-p (when (null (graph-nodes ,graph)) (return-from ,name)))
-       (unless no-verify (verify-graph ,graph))
-       (labels ((,simplifier-bind (,node-top ,count-bind
-				   &aux
-				     (*matched-bind* nil)
-				     (fixed-writes-to
-				      (when ,node-top
-					(loop for o in (graph-outputs ,graph)
-					      if (find (the symbol o) (the list (node-writes ,node-top)) :test #'eql)
-						collect o))))
-		  (declare (type list *matched-bind*))
-		  (when fixed-writes-to (return-from ,simplifier-bind))
-		  (when (null ,node-top) (return-from ,simplifier-bind))		  
-		  (multiple-value-bind (replace-rule matched)
-		      (match ,node-top
-			,@(map 'list #'(lambda (x) (parse-rule x node-top graph)) rules)
-			(_ nil))
-		    (when (and replace-rule matched)
-		      (when (node-p replace-rule) (setf replace-rule (list replace-rule)))
-		      ;; reject the replace-rule only when:
-		      ;; - the original node writes the output to (graph-outputs graph)
-		      ;; - the replaced node breaks this rule
-		      ;;(when fixed-writes-to
-		      ;;  (let ((out (apply #'append (map 'list #'node-writes replace-rule))))
-		      ;;    (when (some #'(lambda (x) (null (find x out))) fixed-writes-to)
-		      ;;      (return-from ,simplifier-bind))))
-		      (if ,fast-graph-p
-			  (insert-nodes ,graph replace-rule)
-			  (setf (graph-nodes ,graph)
-				(nconc
-				 (subseq (graph-nodes ,graph) 0 ,count-bind)
-				 replace-rule
-				 (subseq (graph-nodes ,graph) (1+ ,count-bind)))))
-		      (when (not ,fast-graph-p)
-			;; this may not be required but reduce the number of nodes as many as possible
-			(dolist (r matched)
-			  ;; the top node of matched patten is always replaced.
-			  (when (and (not (eql r (node-id ,node-top))) (id->node ,graph r))
-			    ;; Subsequent nodes are removed if they are not used.
-			    (let ((writes (node-writes (id->node ,graph r))))
-			      (when (every #'(lambda (w) (= (length (the list (id->users ,graph w))) 0)) writes)
-				(remnode ,graph r))))))
-		      t)))
-		(,apply-bind1 (graph &aux (changed-p nil))
-		  (dotimes (nth (length (the list (graph-nodes graph))))
-		    (when (,simplifier-bind (nth nth (the list (graph-nodes graph))) nth)
-		      (setf changed-p t)))
-		  changed-p)
-		(,apply-bind2 (id &key (changed-p nil))
-		  (let ((node (gethash id (%graph-nodes-table ,graph))))
-		    (when node
-		      (when (null (find (the symbol id) (the list ,seen) :test #'eq))
-			(push id ,seen)
-			(when (,simplifier-bind node -1)
-			  (setf changed-p t))
-			(or changed-p (some #'identity (map 'list #',apply-bind2 (node-reads node)))))))))
-	 (if ,fast-graph-p
-	     (loop while (and (some #'identity (map 'list #',apply-bind2 (graph-outputs ,graph))) (setf ,changed-p t)))
-	     (loop while (and (,apply-bind1 ,graph) (setf ,changed-p t))))
-	 (unless no-verify (verify-graph ,graph))
-	 (when return-changed-p (return-from ,name ,changed-p))
-	 ,graph))))
+  (with-gensyms (simplifier-bind apply-bind1 apply-bind2 count-bind fast-graph-p seen changed-p)
+    (let ((node-top '*node-top*) (graph '*graph-bind*))
+      `(defun ,name (,graph &key (no-verify nil) (return-changed-p nil) &aux (,fast-graph-p (typep ,graph 'FastGraph)) (,seen nil) (,changed-p nil))
+         (declare (type graph ,graph)
+		  (type boolean no-verify return-changed-p ,fast-graph-p ,changed-p)
+		  (type list ,seen)
+		  (optimize (speed ,speed)))
+         (unless ,fast-graph-p (when (null (graph-nodes ,graph)) (return-from ,name)))
+         (unless no-verify (verify-graph ,graph))
+         (labels ((,simplifier-bind (,node-top ,count-bind
+				     &aux
+				       (*matched-bind* nil)
+				       (fixed-writes-to
+				        (when ,node-top
+					  (loop for o in (graph-outputs ,graph)
+					        if (find (the symbol o) (the list (node-writes ,node-top)) :test #'eql)
+						  collect o))))
+		    (declare (type list *matched-bind*))
+		    (when fixed-writes-to (return-from ,simplifier-bind))
+		    (when (null ,node-top) (return-from ,simplifier-bind))		  
+		    (multiple-value-bind (replace-rule matched)
+		        (match ,node-top
+			  ,@(map 'list #'(lambda (x) (parse-rule x node-top graph)) rules)
+			  (_ nil))
+		      (when (and replace-rule matched)
+		        (when (node-p replace-rule) (setf replace-rule (list replace-rule)))
+		        ;; reject the replace-rule only when:
+		        ;; - the original node writes the output to (graph-outputs graph)
+		        ;; - the replaced node breaks this rule
+		        ;;(when fixed-writes-to
+		        ;;  (let ((out (apply #'append (map 'list #'node-writes replace-rule))))
+		        ;;    (when (some #'(lambda (x) (null (find x out))) fixed-writes-to)
+		        ;;      (return-from ,simplifier-bind))))
+		        (if ,fast-graph-p
+			    (insert-nodes ,graph replace-rule)
+			    (setf (graph-nodes ,graph)
+				  (nconc
+				   (subseq (graph-nodes ,graph) 0 ,count-bind)
+				   replace-rule
+				   (subseq (graph-nodes ,graph) (1+ ,count-bind)))))
+		        (when (not ,fast-graph-p)
+			  ;; this may not be required but reduce the number of nodes as many as possible
+			  (dolist (r matched)
+			    ;; the top node of matched patten is always replaced.
+			    (when (and (not (eql r (node-id ,node-top))) (id->node ,graph r))
+			      ;; Subsequent nodes are removed if they are not used.
+			      (let ((writes (node-writes (id->node ,graph r))))
+			        (when (every #'(lambda (w) (= (length (the list (id->users ,graph w))) 0)) writes)
+				  (remnode ,graph r))))))
+		        t)))
+		  (,apply-bind1 (graph &aux (changed-p nil))
+		    (dotimes (nth (length (the list (graph-nodes graph))))
+		      (when (,simplifier-bind (nth nth (the list (graph-nodes graph))) nth)
+		        (setf changed-p t)))
+		    changed-p)
+		  (,apply-bind2 (id &key (changed-p nil))
+		    (let ((node (gethash id (%graph-nodes-table ,graph))))
+		      (when node
+		        (when (null (find (the symbol id) (the list ,seen) :test #'eq))
+			  (push id ,seen)
+			  (when (,simplifier-bind node -1)
+			    (setf changed-p t))
+			  (or changed-p (some #'identity (map 'list #',apply-bind2 (node-reads node)))))))))
+	   (if ,fast-graph-p
+	       (loop while (and (some #'identity (map 'list #',apply-bind2 (graph-outputs ,graph))) (setf ,changed-p t)))
+	       (loop while (and (,apply-bind1 ,graph) (setf ,changed-p t))))
+	   (unless no-verify (verify-graph ,graph))
+	   (when return-changed-p (return-from ,name ,changed-p))
+	   ,graph)))))

--- a/source/air/pattern-matcher.lisp
+++ b/source/air/pattern-matcher.lisp
@@ -76,7 +76,7 @@
 (defparameter *matched-bind* nil "a temporary place to store matched nodes during simplifying")
 (defvar *node-top* nil)
 (defvar *graph-bind* nil)
-(defpattern <Rule> (&rest form) (find/replace-rules form '*graph-bind*))
+(defpattern <Rule> (&rest form) (find/replace-rules form '*graph-bind* t))
 
 (defmacro defsimplifier ((name &key (speed 3)) &rest rules)
   "

--- a/source/air/pattern-matcher.lisp
+++ b/source/air/pattern-matcher.lisp
@@ -68,8 +68,18 @@
 	       `((let ((,node ,bind)
 		       (,graph ,graph-bind))
 		   (declare (ignorable ,node ,graph))
-		   ,@body)))
-	      (_ `((progn ,to))))
+		   (let ((result (progn ,@body)))
+                     (when result
+                       (assert (listp result))
+                       (assert (= (length (the list (node-writes (car (last result))))) (length (the list (node-writes ,bind)))))
+                       (setf (node-writes (car (last result))) (node-writes ,bind))
+                       result)))))
+	      (_ `((let ((result (progn ,to)))
+                     (when result
+                       (assert (listp result))
+                       (assert (= (length (the list (node-writes (car (last result))))) (length (the list (node-writes ,bind)))))
+                       (setf (node-writes (car (last result))) (node-writes ,bind))
+                       result)))))
 	  *matched-bind*)))
       (_ (error "Follow this notation: (From_Pattern) -> (To_Pattern).~%~a" rule)))))
 

--- a/source/air/pattern-matcher.lisp
+++ b/source/air/pattern-matcher.lisp
@@ -68,13 +68,15 @@
 	       `((let ((,node ,bind)
 		       (,graph ,graph-bind))
 		   (declare (ignorable ,node ,graph))
-		   (let ((result (progn ,@body)))
+		   (let* ((result (progn ,@body))
+                          (result (if (node-p result) (list result) result)))
                      (when result
                        (assert (listp result))
                        (assert (= (length (the list (node-writes (car (last result))))) (length (the list (node-writes ,bind)))))
                        (setf (node-writes (car (last result))) (node-writes ,bind))
                        result)))))
-	      (_ `((let ((result (progn ,to)))
+	      (_ `((let* ((result (progn ,to))
+                          (result (if (node-p result) (list result) result)))
                      (when result
                        (assert (listp result))
                        (assert (= (length (the list (node-writes (car (last result))))) (length (the list (node-writes ,bind)))))

--- a/source/air/pattern-matcher.lisp
+++ b/source/air/pattern-matcher.lisp
@@ -87,7 +87,7 @@
                `((let* ((val (id->value ,graph-bind ,id)))
                    (when (and (not (eql (node-id val) (node-id ,bind))))
                      (let ((val (copy-node val)))
-                       (assert (= 1 (length (the list (node-writes val))) (length (the list (node-writes ,bind)))) () "-> symbol should only support when (length writes) == 1")
+                       (assert (= 1 (length (the list (node-writes val))) (length (the list (node-writes ,bind)))) () "-> symbol should only support when (length writes) == 1~%~a" ,graph-bind)
                        (purge-graph ,graph-bind (car (node-writes val)) (car (node-writes ,bind)))
                        (setf (node-writes val) (node-writes ,bind))
                        (list val))))))

--- a/source/air/test-suites.lisp
+++ b/source/air/test-suites.lisp
@@ -6,7 +6,7 @@
 (in-package :caten/air.test)
 
 ;; ~~ helpers ~~~~~~~~~~~~~~~~~~~~~~~~~
-(defun <node> (type writes reads &rest attrs) (apply #'make-node :node type writes reads attrs))
+(defun <node> (type writes reads &rest attrs) (apply #'make-node :Testing type writes reads attrs))
 (defun compare (graph expected
 		&key
 		  (slots `(caten/air::writes caten/air::reads caten/air::type caten/air::class))

--- a/source/apis/helpers.lisp
+++ b/source/apis/helpers.lisp
@@ -37,9 +37,9 @@
 
 (defun try-fold-constant (tensor)
   (declare (type Tensor tensor))
-  (let ((graph (fold-constant (%tensor->aasm tensor))))
+  (let ((graph (fold-constant (->fast-graph (%tensor->aasm tensor)))))
     (when (= (length (graph-nodes graph)) 2)
-      (%obtain-fold-constant-result graph :no-verify t)
+      (%obtain-fold-constant-result graph)
       (when (and (= (length (graph-nodes graph)) 1)
 		 (eql :_TmpScalarConst (node-type (car (graph-nodes graph)))))
 	(car (node-reads (car (graph-nodes graph))))))))

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -499,6 +499,5 @@ Compiles the given tensors, returning an evaluated tensors.
 (defun %tensor->aasm (&rest tensors)
   (let* ((sess (make-compiler-session :name :tensor->aasm))
          (graph (%lower-iseq sess (apply #'%tpsort-tensors sess tensors))))
-    ;; [TODO]: Use FastGraph
-    ;; (setf (graph-outputs graph) (map 'list #'(lambda (x) (car (node-writes (session/read sess (tensor-id x))))) tensors))
+    (setf (graph-outputs graph) (map 'list #'(lambda (x) (car (node-writes (session/read sess (tensor-id x))))) tensors))
     graph))

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -497,5 +497,8 @@ Compiles the given tensors, returning an evaluated tensors.
   (forward (caten tensors)))
 
 (defun %tensor->aasm (&rest tensors)
-  (let ((sess (make-compiler-session :name :tensor->aasm)))
-    (%lower-iseq sess (apply #'%tpsort-tensors sess tensors))))
+  (let* ((sess (make-compiler-session :name :tensor->aasm))
+         (graph (%lower-iseq sess (apply #'%tpsort-tensors sess tensors))))
+    ;; [TODO]: Use FastGraph
+    ;; (setf (graph-outputs graph) (map 'list #'(lambda (x) (car (node-writes (session/read sess (tensor-id x))))) tensors))
+    graph))

--- a/source/apis/test-suites.lisp
+++ b/source/apis/test-suites.lisp
@@ -117,8 +117,8 @@
     (ok (check-schedule (caten (!neg (!mul (iconst 'a) (iconst 1)))) 3))
 
     ;; the top should not folded
-    (ok (check-schedule (caten (!add (iconst 0) (iconst 'a))) 5))
-    (ok (check-schedule (caten (!mul (iconst 0) (iconst 'a))) 5))
+    (ok (check-schedule (caten (!add (iconst 0) (iconst 'a))) 2))
+    (ok (check-schedule (caten (!mul (iconst 0) (iconst 'a))) 1))
     
     (ok (= 1 (elements (pproceed `((a . 1)) (!add (iconst 0) (iconst 'a))))))
     (ok (= -1 (elements (pproceed `((a . 1)) (!neg (!add (iconst 0) (iconst 'a)))))))

--- a/source/codegen/expr.lisp
+++ b/source/codegen/expr.lisp
@@ -100,12 +100,10 @@ Only supports the scalar computation because it is intended to identify the same
 (defmethod simplify-expr ((expr Expr))
   (let ((out (graph-outputs (expr-graph expr))))
     (assert (= (length out) 1))
-    (setf (graph-outputs (expr-graph expr)) nil)
-    ;; Setting (graph-outputs out) = nil to simplify the last expr.
     (optimize-aasm (expr-graph expr))
-    (assert (= (length (nodes-write-to (graph-nodes (expr-graph expr)))) 1))
-    (setf (graph-outputs (expr-graph expr)) (nodes-write-to (graph-nodes (expr-graph expr)))
-          (expr-out expr) (id->value (expr-graph expr) (car (graph-outputs (expr-graph expr)))))
+    ;;(assert (= (length (nodes-write-to (graph-nodes (expr-graph expr)))) 1) () "simplify-expr: failed to simplify the expr to have a single output... something went wrong during the compilation process.")
+    ;;(setf (graph-outputs (expr-graph expr)) (nodes-write-to (graph-nodes (expr-graph expr)))
+    ;;      (expr-out expr) (id->value (expr-graph expr) (car (graph-outputs (expr-graph expr)))))
     expr))
 
 (defun %connect-expr (grh args out)


### PR DESCRIPTION
- [x] optimize: `optimize-aasm`
  - [x] no recursive function calling in `fold-constant`
- [x] bugfix on defsimplifier
  - [x] `node-class`
  - [x] recurisve node creation
  - [x] `<node>`
  - [x] ids appeared in the outputs should be simplified
  - [x] optimize pattern matcher, constant folding < 1e-5 sec
  - [ ] Full optimization on %tensor->aasm (make it zero cost for smaller graph)
  - [ ] !view < 1e-4sec without using fixnum