### PR TITLE
defsimplifier is O(N)

### DIFF
--- a/.github/workflows/tests_on_push.yml
+++ b/.github/workflows/tests_on_push.yml
@@ -103,6 +103,6 @@ jobs:
       - name: Transformer Simplifiers (N<=12, JIT=0, AUTO_SCHEDULER=0)
         run: PROFILE_SIMPLIFIER=1 ./roswell/caten.ros benchmark transformer_compile_time 36 0 transformer_simplifier_plot.png
       - name: Transformer Schedulers (N<=12, JIT=1, AUTO_SCHEDULER=0)
-        run: PROFILE_SIMPLIFIER=1 JIT_DEBUG=2 AUTO_SCHEDULER=0 ./roswell/caten.ros benchmark transformer_compile_time 24 1 transformer_simplifier_no_auto_sched_plot.png
+        run: PROFILE_SIMPLIFIER=1 JIT_DEBUG=2 AUTO_SCHEDULER=0 ./roswell/caten.ros benchmark transformer_compile_time 12 1 transformer_simplifier_no_auto_sched_plot.png
 #      - name: Transformer Schedulers (N<=12, JIT=1, AUTO_SCHEDULER=1)
 #        run: PROFILE_SIMPLIFIER=1 JIT_DEBUG=2 AUTO_SCHEDULER=1 ./roswell/caten.ros benchmark transformer_compile_time 24 1 transformer_simplifier_auto_scheduler_plot.png

--- a/.github/workflows/tests_on_push.yml
+++ b/.github/workflows/tests_on_push.yml
@@ -101,8 +101,8 @@ jobs:
       - name: Installing Dependencies
         run: sudo apt-get install -y libisl-dev gnuplot
       - name: Transformer Simplifiers (N<=12, JIT=0, AUTO_SCHEDULER=0)
-        run: ./roswell/caten.ros benchmark transformer_compile_time 12 0 transformer_simplifier_plot.png
+        run: PROFILE_SIMPLIFIER=1 ./roswell/caten.ros benchmark transformer_compile_time 36 0 transformer_simplifier_plot.png
       - name: Transformer Schedulers (N<=12, JIT=1, AUTO_SCHEDULER=0)
-        run: JIT_DEBUG=2 AUTO_SCHEDULER=0 ./roswell/caten.ros benchmark transformer_compile_time 12 1 transformer_simplifier_no_auto_sched_plot.png
+        run: PROFILE_SIMPLIFIER=1 JIT_DEBUG=2 AUTO_SCHEDULER=0 ./roswell/caten.ros benchmark transformer_compile_time 24 1 transformer_simplifier_no_auto_sched_plot.png
 #      - name: Transformer Schedulers (N<=12, JIT=1, AUTO_SCHEDULER=1)
-#        run: JIT_DEBUG=2 AUTO_SCHEDULER=1 ./roswell/caten.ros benchmark transformer_compile_time 12 1 transformer_simplifier_auto_scheduler_plot.png
+#        run: PROFILE_SIMPLIFIER=1 JIT_DEBUG=2 AUTO_SCHEDULER=1 ./roswell/caten.ros benchmark transformer_compile_time 24 1 transformer_simplifier_auto_scheduler_plot.png

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@
 /.qlot
 qlfile
 qlfile.lock
+
+*.fasl
+*.swp
+\#*\#
+.\#*
+.DS_Store
+*~

--- a/source/aasm/constant-folding.lisp
+++ b/source/aasm/constant-folding.lisp
@@ -137,7 +137,7 @@
      ->
      ((node graph) (sfold-view ss node graph nrank broadcast permute))))
 
-(defun fold-constant (graph)
-  (apply-fold-constant graph)
-  (fuse-vmops graph)
+(defun fold-constant (graph &key (debug-opt nil))
+  (apply-fold-constant graph :debug-opt debug-opt)
+  (fuse-vmops graph :debug-opt debug-opt)
   graph)

--- a/source/aasm/optimizers.lisp
+++ b/source/aasm/optimizers.lisp
@@ -84,7 +84,7 @@ This may reduce the compilation time of the dynamic kernel dramatically, also si
     (verify-graph graph)
     graph))
 
-(defun optimize-aasm (graph)
-  (fold-constant graph)
+(defun optimize-aasm (graph &key (debug-opt nil))
+  (fold-constant graph :debug-opt debug-opt)
   (simplify-dynamic-arithmetic graph)
   (fuse-duplicated-store graph))

--- a/source/air/pattern-matcher.lisp
+++ b/source/air/pattern-matcher.lisp
@@ -195,7 +195,7 @@ The `graph` is a graph to simplify. The `no-verify` is a flag to skip the verifi
 	       (loop while (and (some #'identity (map 'list #',apply-bind2 (graph-outputs ,graph)))
                                 (progn (setf ,seen nil) (setf ,changed-p t))))
 	       (loop while (and (,apply-bind1 ,graph) (setf ,changed-p t))))
-           (when debug-opt (format t "~a: ~a calls for ~a nodes (~a%)~%" ',name ,counter ,n-nodes (float (/ ,n-nodes ,counter))))
+           (when debug-opt (format t "~a: ~a calls for ~a nodes (~a%)~%" ',name ,counter ,n-nodes (float (/ ,counter ,n-nodes))))
 	   (unless no-verify (verify-graph ,graph))
 	   (when return-changed-p (return-from ,name ,changed-p))
 	   ,graph)))))

--- a/source/air/pattern-matcher.lisp
+++ b/source/air/pattern-matcher.lisp
@@ -105,7 +105,8 @@
 (defvar *node-top* nil)
 (defvar *graph-bind* nil)
 (defpattern <Rule> (&rest form) (find/replace-rules form '*graph-bind* t))
-
+;; Simplifier Computation Order:
+;; - FastGraph: O(n) where n = the depth of rewriting patterns
 (defmacro defsimplifier ((name &key (speed 3)) &rest rules)
   "
 ```

--- a/source/air/pattern-matcher.lisp
+++ b/source/air/pattern-matcher.lisp
@@ -195,7 +195,7 @@ The `graph` is a graph to simplify. The `no-verify` is a flag to skip the verifi
 	       (loop while (and (some #'identity (map 'list #',apply-bind2 (graph-outputs ,graph)))
                                 (progn (setf ,seen nil) (setf ,changed-p t))))
 	       (loop while (and (,apply-bind1 ,graph) (setf ,changed-p t))))
-           (when debug-opt (format t "~a: ~a calls for ~a nodes (~a%)~%" ',name ,counter ,n-nodes (float (/ ,counter ,n-nodes))))
+           (when debug-opt (format t "~a: ~a calls for ~a nodes (~a%)~%" ',name ,counter ,n-nodes (float (* 100.0 (/ ,counter ,n-nodes)))))
 	   (unless no-verify (verify-graph ,graph))
 	   (when return-changed-p (return-from ,name ,changed-p))
 	   ,graph)))))

--- a/source/air/pattern-matcher.lisp
+++ b/source/air/pattern-matcher.lisp
@@ -182,15 +182,15 @@ The `graph` is a graph to simplify. The `no-verify` is a flag to skip the verifi
 		      (when (,simplifier-bind (nth nth (the list (graph-nodes graph))) nth)
 		        (setf changed-p t)))
 		    changed-p)
-		  (,apply-bind2 (id &key (changed-p nil))
+		  (,apply-bind2 (id)
 		    (let ((node (gethash id (%graph-nodes-table ,graph))))
 		      (when node
 		        (when (null (find (the symbol id) (the list ,seen) :test #'eq))
 			  (push id ,seen)
 			  (when (,simplifier-bind node -1)
-			    (setf changed-p t))
+                            (return-from ,apply-bind2 t))
                           ;; If changed path was found => restart from the top of graph
-                          (or changed-p (some #'identity (map 'list #',apply-bind2 (node-reads node)))))))))
+                          (some #'identity (map 'list #',apply-bind2 (node-reads node))))))))
 	   (if ,fast-graph-p
 	       (loop while (and (some #'identity (map 'list #',apply-bind2 (graph-outputs ,graph)))
                                 (progn (setf ,seen nil) (setf ,changed-p t))))

--- a/source/air/pattern-matcher.lisp
+++ b/source/air/pattern-matcher.lisp
@@ -188,8 +188,8 @@ The `graph` is a graph to simplify. The `no-verify` is a flag to skip the verifi
 		        (when (null (find (the symbol id) (the list ,seen) :test #'eq))
 			  (push id ,seen)
 			  (when (,simplifier-bind node -1)
+                            (some #'identity (map 'list #',apply-bind2 (node-reads node)))
                             (return-from ,apply-bind2 t))
-                          ;; If changed path was found => restart from the top of graph
                           (some #'identity (map 'list #',apply-bind2 (node-reads node))))))))
 	   (if ,fast-graph-p
 	       (loop while (and (some #'identity (map 'list #',apply-bind2 (graph-outputs ,graph)))

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -268,7 +268,7 @@
 	  (let ((merged-graph (->fast-graph merged-graph)))
             (lower-all merged-graph)
 	    ;; Function-level whole optimization
-            (dolist (f external-simplifiers) (funcall f merged-graph)) ;; SLOW
+            (dolist (f external-simplifiers) (funcall f merged-graph)) ;; [TODO] delete this
 	    ;; verify and complete
             (verify-graph merged-graph)
 	    (values (->graph-with-tpsort merged-graph) pause-backward-p)))))))

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -268,7 +268,8 @@
 	  (let ((merged-graph (->fast-graph merged-graph)))
             (lower-all merged-graph)
 	    ;; Function-level whole optimization
-            (dolist (f external-simplifiers) (funcall f merged-graph :debug-opt t)) ;; [TODO] delete this
+            (dolist (f external-simplifiers)
+              (funcall f merged-graph :debug-opt (= 1 (the fixnum (ctx:getenv :PROFILE_SIMPLIFIER)))))
 	    ;; verify and complete
             (verify-graph merged-graph)
 	    (values (->graph-with-tpsort merged-graph) pause-backward-p)))))))

--- a/source/apis/iseq.lisp
+++ b/source/apis/iseq.lisp
@@ -268,7 +268,7 @@
 	  (let ((merged-graph (->fast-graph merged-graph)))
             (lower-all merged-graph)
 	    ;; Function-level whole optimization
-            (dolist (f external-simplifiers) (funcall f merged-graph)) ;; [TODO] delete this
+            (dolist (f external-simplifiers) (funcall f merged-graph :debug-opt t)) ;; [TODO] delete this
 	    ;; verify and complete
             (verify-graph merged-graph)
 	    (values (->graph-with-tpsort merged-graph) pause-backward-p)))))))

--- a/source/common/contextvar.lisp
+++ b/source/common/contextvar.lisp
@@ -204,6 +204,9 @@ Usage:
      "Use cl-ansi-color if set to 1")
     (:SAFETY
      0 :int #.(oneof "SAFETY" 0 `(0 1))
-     "When this parameter is set to 1, caten/air checks that all dependencies are satisfied during each process of Graph Rewriting. (i.e.: FastGraph becomes Graph) This directly impacts the compilation speed.")))
+     "When this parameter is set to 1, caten/air checks that all dependencies are satisfied during each process of Graph Rewriting. (i.e.: FastGraph becomes Graph) This directly impacts the compilation speed.")
+    (:PROFILE_SIMPLIFIER
+     0 :int #.(oneof "PROFILE_SIMPLIFIER" 0 `(0 1))
+     "Set 1 to profile the simplifier in %make-graph-from-iseq")))
 
 (defparameter *ctx* (make-contextvar))


### PR DESCRIPTION
- [x] Remove the simplifier to the entire graph
- [x] Increase the limit of benchmark from N=12 to N=32
- [x] Optimize defsimplifier for handing the large graph. If that's O(N), jit should be also O(n)
- [x] Set restart-points for fastgraph simplified. Simplifyされた経路を記録して次のgraph-outputsとして使う
- [x] 99% of simplifier time for the large graph computation is used for the mearningless node comparison
- [ ] JIT always use FastGraph
- [ ] optimize-aasm may be slow (simplify-dynamic-arithmetic)
```
CATEN/LLM> (defparameter *transformer* (time (caten (forward *model* (make-tensor `(10 32)) (iconst 1)))))
COMPOSE-VIEWS-FROM-GRAPH: 56095 calls for 2302 nodes (24.36794%)
APPLY-FOLD-CONSTANT: 5205 calls for 1871 nodes (2.7819347%)
FUSE-VMOPS: 1748 calls for 1748 nodes (1.0%)
Evaluation took:
  0.796 seconds of real time
  0.778812 seconds of total run time (0.686056 user, 0.092756 system)
  97.86% CPU
  599,419,392 bytes consed
  
*TRANSFORMER*
CATEN/LLM> 
```