### PR TITLE
BugFix: Fix structures to be visible at compile time from `trivia` library

### DIFF
--- a/source/codegen/polyhedral-ast.lisp
+++ b/source/codegen/polyhedral-ast.lisp
@@ -5,28 +5,30 @@
 
 (in-package :caten/codegen/polyhedral-ast)
 ;; ~~ ISL AST <-> Lisp Intermidate Object ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-(defstruct (ASTBlock
-	    (:constructor make-block (body)))
-  (body body :type list))
 
-(defstruct (User
-	    (:constructor make-user (name args)))
-  "T_name(index)"
-  (name name :type string) (args args :type list))
+(eval-when (:execute :compile-toplevel :load-toplevel)
+  (defstruct (ASTBlock
+              (:constructor make-block (body)))
+    (body body :type list))
 
-(defstruct (ASTFor
-	    (:constructor make-for (idx from to by body)))
-  (idx idx :type string)
-  (from from :type Expr)
-  (to to :type Expr)
-  (by by :type Expr)
-  (body body :type (or ASTBlock User ASTFor ASTIF)))
+  (defstruct (User
+              (:constructor make-user (name args)))
+    "T_name(index)"
+    (name name :type string) (args args :type list))
 
-(defstruct (AstIf
-	    (:constructor make-if (condition then-node else-node)))
-  (condition condition :type Expr)
-  (then-node then-node :type (or ASTBlock User ASTFOR ASTIF))
-  (else-node else-node :type (or ASTBlock User ASTFOR ASTIF null)))
+  (defstruct (ASTFor
+              (:constructor make-for (idx from to by body)))
+    (idx idx :type string)
+    (from from :type Expr)
+    (to to :type Expr)
+    (by by :type Expr)
+    (body body :type (or ASTBlock User ASTFor ASTIF)))
+
+  (defstruct (AstIf
+              (:constructor make-if (condition then-node else-node)))
+    (condition condition :type Expr)
+    (then-node then-node :type (or ASTBlock User ASTFOR ASTIF))
+    (else-node else-node :type (or ASTBlock User ASTFOR ASTIF null))))
 
 (declaim (ftype (function (cffi:foreign-pointer) t) parse-isl-ast))
 (defun parse-isl-ast (ast)


### PR DESCRIPTION
Fix for the following error message when compiling with Clozure CL

```
; While executing: ALEXANDRIA:SIMPLE-STYLE-WARNING, in process listener(1).
> Error: Symbol ASTBLOCK is unbound in namespace PATTERN
> While executing: PATTERN-EXPAND-1, in process listener(1).
> Type :GO to continue, :POP to abort, :R for a list of available restarts.
> If continued: Skip evaluation of (ros:run '((:eval"(ros:quicklisp)")(:source-registry ".")(:eval "(asdf:compile-system \"caten\" :verbose t)")))
> Type :? for other options.
```
