### PR TITLE
Opt: Faster Symbolic Lowerer

### DIFF
--- a/external/benchmarks/benchmark-simplifier.lisp
+++ b/external/benchmarks/benchmark-simplifier.lisp
@@ -8,12 +8,13 @@
   (ctx:with-contextvar (:JIT 1) (Transformer 128 8 n-layers 1e-5 32)))
 
 (defun measure-simplify-time (model jit)
-  (ctx:with-contextvar (:JIT jit)
-    (let ((started (get-internal-real-time)))
-      ;; TODO: Try full symbolic once we implement a module-wise asm cache
-      (caten (forward model (make-tensor `(1 2)) (iconst 1)))
-      (let ((finished (get-internal-real-time)))
-        (float (/ (- finished started) internal-time-units-per-second))))))
+  (with-inference-mode ()
+    (ctx:with-contextvar (:JIT jit)
+      (let ((started (get-internal-real-time)))
+        ;; TODO: Try full symbolic once we implement a module-wise asm cache
+        (caten (forward model (make-tensor `(1 2)) (iconst 1)))
+        (let ((finished (get-internal-real-time)))
+          (float (/ (- finished started) internal-time-units-per-second)))))))
 
 ;; brew install gnuplot for prepreq
 (defun run (&key (n 12) (jit 0) (path nil))

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -1,8 +1,5 @@
 (in-package :caten/test-suite)
 
-;; - (defparameter *model* (time (Transformer 64 1 2 1e-5 32)))
-;; - (defparameter *transformer* (caten (call *model* (make-tensor `(10 32)) (iconst 'n))))
-
 (deftest symbolic-function-args-test
   (with-protect-jit
     (let ((kernel (find :JIT_KERNEL (graph-nodes (avm-graph (caten (!add (!view (make-tensor `(n)) `(froma toa bya)) (!view (make-tensor `(n)) `(fromb tob byb)))))) :key #'node-type)))
@@ -57,7 +54,6 @@
          (m (caten (!add (!add (!index-components `(5)) (!add caten/apis::*rng-counter* (!* (iconst 2) (iconst 'n)) :reduce t))  (!* (iconst 2) (iconst 'n)))))
          (o `(,(+ x (* 4 4)) ,(+ x (* 4 4) 1) ,(+ x (* 4 4) 2) ,(+ x (* 4 4) 3))))
     (ok (every #'= o (elements (forward m `(n . 4)))))))
-
 ;; Transformer-Failing-Case-Repro:
 ;; ```
 ;; LOAD: val_3 = N
@@ -103,3 +99,6 @@
          (s 's)
          (mask (!triu (!full `(1 1 ,s ,(!+ (iconst s) (iconst 1))) (-inf)) :diagonal (!+ (iconst 1) n))))
     (ok (caten mask))))
+
+;; TODO: test-matmul, test-attetnion, test-ffn etc for dynamic shape
+;; having descent tests like tinygrad does (incresing the size from 0 to n ...)


### PR DESCRIPTION
## Workload

- [x] Improve the speed of lowering full symbolic schedule-item (remove expr-scalar-equivalent-p)
- [x] Improve the scheduling/simplifying time for the full symbolic
- [ ] optimize remove-unused-blueprint
- [ ] improve the simplifying time
- [ ] CI: Benchmark with symbolic
- [ ] Tests: having decent tests for full symbolic (for gemm, attention, etc...)
- [ ] Repro and test for #272 
- [ ] NOOPT=1 produces a warning with Transformer?