### PR TITLE
more tests on symbolic

### DIFF
--- a/source/codegen/jit.lisp
+++ b/source/codegen/jit.lisp
@@ -259,8 +259,11 @@ caten/codegen overview:
                  if (null (find w allocated)) do
                    (mapc #'merge-id (append (buffer-shape wt) (buffer-stride wt) (apply #'append (buffer-views wt))))
                    (multiple-value-bind (view alloc) (make-alloc+view-node-from-buffer wt w)
+                     (mapc #'merge-id (node-reads alloc))
                      (push alloc nodes)
-                     (when view (push view nodes)))
+                     (when view
+                       (mapc #'merge-id (node-reads view))
+                       (push view nodes)))
                    (push w allocated))
            (loop for (s . type) in (getattr node :dynamic-shapes)
                  if (and (null (find s allocated)) (id->value base-graph s)) do

--- a/source/codegen/scheduler.lisp
+++ b/source/codegen/scheduler.lisp
@@ -728,9 +728,7 @@ This function will put a copy of LOAD if some of nodes in group-items stop right
     (loop for predecessor in (group-predecessor group)
           for item = (id->value (ctx-graph ctx) predecessor)
           if (and item (eql (node-type item) :LOAD)
-                  (= 0 (buffer-nrank (car (relay-writes (read-type-relay item)))))
-                  ;; note(hikettei) do not apply this for dynamic shape loading
-                  (numberp (getattr item :value)))
+                  (= 0 (buffer-nrank (car (relay-writes (read-type-relay item))))))
             do (setf (group-predecessor group) (remove predecessor (group-predecessor group)))
                (push item (group-items group))))
   group)

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -102,3 +102,4 @@
 
 ;; TODO: test-matmul, test-attetnion, test-ffn etc for dynamic shape
 ;; having descent tests like tinygrad does (incresing the size from 0 to n ...)
+

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -99,9 +99,13 @@
          (s 's)
          (mask (!triu (!full `(1 1 ,s ,(!+ (iconst s) (iconst 1))) (-inf)) :diagonal (!+ (iconst 1) n))))
     (ok (caten mask))))
-;; ~~ Symbolic Accuracy Testing ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-;; [TODO] val_8 is a scalar.
-
-
-;; TODO: test-matmul, test-attetnion, test-ffn etc for dynamic shape
-;; having descent tests like tinygrad does (incresing the size from 0 to n ...)
+;; ~~ Symbolic Accuracy Testing ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(deftest symbolic-matmul-test
+  (loop with m = (caten (!matmul (make-tensor `(a a) :from 'x) (make-tensor `(a a) :from 'y)))
+        for a upfrom 10 below 20
+        for x = (rand `(,a ,a))
+        for y = (rand `(,a ,a))
+        for symbolic = (forward m `(a . ,a) `(x . ,x) `(y . ,y))
+        for expected = (proceed (!matmul x y))
+        do (setf (tensor-shape symbolic) (tensor-shape expected)) ;; Symbolic returns `(A A) tensor.
+           (assert-equal () symbolic expected)))

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -99,6 +99,13 @@
          (s 's)
          (mask (!triu (!full `(1 1 ,s ,(!+ (iconst s) (iconst 1))) (-inf)) :diagonal (!+ (iconst 1) n))))
     (ok (caten mask))))
+;; ~~ Symbolic Accuracy Testing ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(defun symbolic-fail-repro ()
+  (with-no-grad
+    (let* ((n (iconst 'n))
+           (out (!add (call (Embedding 10 10) (make-tensor `(10 10))) (call (Embedding 10 10) (!cast (!add n (!index-components `(1 10))) :float32)))))
+      (caten (!add (!matmul out (!t out)) n)))))
+;; [TODO] val_8 is a scalar.
 
 ;; TODO: test-matmul, test-attetnion, test-ffn etc for dynamic shape
 ;; having descent tests like tinygrad does (incresing the size from 0 to n ...)

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -130,15 +130,14 @@
                          (make-tensor `(b s 32) :from 'key)
                          (make-tensor `(b s 32) :from 'value)))
         for s upfrom 10 below 13 do
-          (loop for b upfrom 2 below 4 do
-            (loop
-              for query = (randn `(,b ,s 32))
-              for key   = (randn `(,b ,s 32))
-              for value = (randn `(,b ,s 32))
-              for symbolic = (forward m `(s . ,s) `(b . ,b) `(query . ,query) `(key . ,key) `(value . ,value))
-              for expected = (proceed (scaled-dot-product-attention query key value))
-              do (setf (tensor-shape symbolic) (tensor-shape expected))
-                 (assert-equal () symbolic expected)))))
+          (loop for b upfrom 2 below 4
+                for query = (randn `(,b ,s 32))
+                for key   = (randn `(,b ,s 32))
+                for value = (randn `(,b ,s 32))
+                for symbolic = (forward m `(s . ,s) `(b . ,b) `(query . ,query) `(key . ,key) `(value . ,value))
+                for expected = (proceed (scaled-dot-product-attention query key value))
+                do (setf (tensor-shape symbolic) (tensor-shape expected))
+                   (assert-equal () symbolic expected))))
 
 (deftest symbolic-tensor-shaped-triu-test
   (loop with n = (iconst 'n)

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -173,6 +173,7 @@
                    (assert-equal () symbolic expected))))
 |#
 
+#|
 (deftest symbolic-tensor-shaped-two-kernel-test-2
   (loop with n = (iconst 'n)
         with s = (iconst 's)
@@ -189,3 +190,4 @@
                                  (!sum (!triu (!full `(1 1 ,(+ nn ss) ,ss) 5.0) :diagonal (+ 1 nn)))))
                 do (setf (tensor-shape symbolic) (tensor-shape expected))
                    (assert-equal () symbolic expected))))
+|#

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -149,7 +149,8 @@
                 for expected = (proceed (!triu (!full `(1 1 ,(+ nn ss) ,ss) 5.0) :diagonal (+ 1 nn)))
                 do (setf (tensor-shape symbolic) (tensor-shape expected))
                    (assert-equal () symbolic expected))))
-
+;; Failing
+#|
 (deftest symbolic-tensor-shaped-two-kernel-test-1
   (loop with n = (iconst 'n)
         with s = (iconst 's)
@@ -185,3 +186,4 @@
                                  (!sum (!triu (!full `(1 1 ,(+ nn ss) ,ss) 5.0) :diagonal (+ 1 nn)))))
                 do (setf (tensor-shape symbolic) (tensor-shape expected))
                    (assert-equal () symbolic expected))))
+|#

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -151,8 +151,6 @@
                 do (setf (tensor-shape symbolic) (tensor-shape expected))
                    (assert-equal () symbolic expected))))
 
-;; Failing case!
-#|
 (deftest symbolic-tensor-shaped-two-kernel-test-1
   (loop with n = (iconst 'n)
         with s = (iconst 's)
@@ -171,9 +169,7 @@
                                  (!sum (!triu (!full `(1 1 ,(+ nn ss) ,ss) 5.0) :diagonal (+ 1 nn)))))
                 do (setf (tensor-shape symbolic) (tensor-shape expected))
                    (assert-equal () symbolic expected))))
-|#
 
-#|
 (deftest symbolic-tensor-shaped-two-kernel-test-2
   (loop with n = (iconst 'n)
         with s = (iconst 's)
@@ -190,4 +186,3 @@
                                  (!sum (!triu (!full `(1 1 ,(+ nn ss) ,ss) 5.0) :diagonal (+ 1 nn)))))
                 do (setf (tensor-shape symbolic) (tensor-shape expected))
                    (assert-equal () symbolic expected))))
-|#

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -143,10 +143,10 @@
 (deftest symbolic-tensor-shaped-triu-test
   (loop with n = (iconst 'n)
         with s = (iconst 's)
-        with m = (caten (!triu (!full `(1 1 ,(!+ n s) ,s) (-inf)) :diagonal (!+ (iconst 1) n)))
+        with m = (caten (!triu (!full `(1 1 ,(!+ n s) ,s) 5.0) :diagonal (!+ (iconst 1) n)))
         for nn upfrom 10 below 13 do
           (loop for ss upfrom 10 below 13
                 for symbolic = (forward m `(s . ,ss) `(n . ,nn))
-                for expected = (proceed (!triu (!full `(1 1 ,(+ nn ss) ,ss) (-inf)) :diagonal (+ 1 nn)))
+                for expected = (proceed (!triu (!full `(1 1 ,(+ nn ss) ,ss) 5.0) :diagonal (+ 1 nn)))
                 do (setf (tensor-shape symbolic) (tensor-shape expected))
                    (assert-equal () symbolic expected))))

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -150,3 +150,42 @@
                 for expected = (proceed (!triu (!full `(1 1 ,(+ nn ss) ,ss) 5.0) :diagonal (+ 1 nn)))
                 do (setf (tensor-shape symbolic) (tensor-shape expected))
                    (assert-equal () symbolic expected))))
+
+;; Failing case!
+#|
+(deftest symbolic-tensor-shaped-two-kernel-test-1
+  (loop with n = (iconst 'n)
+        with s = (iconst 's)
+        with m = (caten
+                  (!mul
+                   (!matmul (!triu (!full `(1 1 ,(!+ n s) ,s) 5.0) :diagonal (!+ (iconst 1) n))
+                            (!t (!triu (!full `(1 1 ,(!+ n s) ,s) 5.0) :diagonal (!+ (iconst 1) n))))
+                   (!sum (!triu (!full `(1 1 ,(!+ n s) ,s) 5.0) :diagonal (!+ (iconst 1) n)))))
+        for nn upfrom 10 below 13 do
+          (loop for ss upfrom 10 below 13
+                for symbolic = (forward m `(s . ,ss) `(n . ,nn))
+                for expected = (proceed
+                                (!mul
+                                 (!matmul (!triu (!full `(1 1 ,(+ nn ss) ,ss) 5.0) :diagonal (+ 1 nn))
+                                          (!t (!triu (!full `(1 1 ,(+ nn ss) ,ss) 5.0) :diagonal (+ 1 nn))))
+                                 (!sum (!triu (!full `(1 1 ,(+ nn ss) ,ss) 5.0) :diagonal (+ 1 nn)))))
+                do (setf (tensor-shape symbolic) (tensor-shape expected))
+                   (assert-equal () symbolic expected))))
+|#
+
+(deftest symbolic-tensor-shaped-two-kernel-test-2
+  (loop with n = (iconst 'n)
+        with s = (iconst 's)
+        with m = (caten
+                  (!mul
+                   (!matmul (ax+b `(,n ,s) n s) (ax+b `(,s ,n) s n))
+                   (!sum (!triu (!full `(1 1 ,(!+ n s) ,s) 5.0) :diagonal (!+ (iconst 1) n)))))
+        for nn upfrom 10 below 13 do
+          (loop for ss upfrom 10 below 13
+                for symbolic = (forward m `(s . ,ss) `(n . ,nn))
+                for expected = (proceed
+                                (!mul
+                                 (!matmul (ax+b `(,nn ,ss) nn ss) (ax+b `(,ss ,nn) ss nn))
+                                 (!sum (!triu (!full `(1 1 ,(+ nn ss) ,ss) 5.0) :diagonal (+ 1 nn)))))
+                do (setf (tensor-shape symbolic) (tensor-shape expected))
+                   (assert-equal () symbolic expected))))

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -109,3 +109,33 @@
         for expected = (proceed (!matmul x y))
         do (setf (tensor-shape symbolic) (tensor-shape expected)) ;; Symbolic returns `(A A) tensor.
            (assert-equal () symbolic expected)))
+
+(deftest symbolic-scaled-dot-product-attention-test
+  (loop with m = (caten (scaled-dot-product-attention
+                         (make-tensor `(2 s 64) :from 'query)
+                         (make-tensor `(2 s 64) :from 'key)
+                         (make-tensor `(2 s 64) :from 'value)))
+        for s upfrom 10 below 20
+        for query = (randn `(2 ,s 64))
+        for key   = (randn `(2 ,s 64))
+        for value = (randn `(2 ,s 64))
+        for symbolic = (forward m `(s . ,s) `(query . ,query) `(key . ,key) `(value . ,value))
+        for expected = (proceed (scaled-dot-product-attention query key value))
+        do (setf (tensor-shape symbolic) (tensor-shape expected))
+           (assert-equal () symbolic expected)))
+
+(deftest full-symbolic-scaled-dot-product-attention-test
+  (loop with m = (caten (scaled-dot-product-attention
+                         (make-tensor `(b s 32) :from 'query)
+                         (make-tensor `(b s 32) :from 'key)
+                         (make-tensor `(b s 32) :from 'value)))
+        for s upfrom 10 below 13 do
+          (loop for b upfrom 2 below 4 do
+            (loop
+              for query = (randn `(,b ,s 32))
+              for key   = (randn `(,b ,s 32))
+              for value = (randn `(,b ,s 32))
+              for symbolic = (forward m `(s . ,s) `(b . ,b) `(query . ,query) `(key . ,key) `(value . ,value))
+              for expected = (proceed (scaled-dot-product-attention query key value))
+              do (setf (tensor-shape symbolic) (tensor-shape expected))
+                 (assert-equal () symbolic expected)))))

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -100,13 +100,8 @@
          (mask (!triu (!full `(1 1 ,s ,(!+ (iconst s) (iconst 1))) (-inf)) :diagonal (!+ (iconst 1) n))))
     (ok (caten mask))))
 ;; ~~ Symbolic Accuracy Testing ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-(defun symbolic-fail-repro ()
-  (with-no-grad
-    (let* ((n (iconst 'n))
-           (out (!add (call (Embedding 10 10) (make-tensor `(10 10))) (call (Embedding 10 10) (!cast (!add n (!index-components `(1 10))) :float32)))))
-      (caten (!add (!matmul out (!t out)) n)))))
 ;; [TODO] val_8 is a scalar.
+
 
 ;; TODO: test-matmul, test-attetnion, test-ffn etc for dynamic shape
 ;; having descent tests like tinygrad does (incresing the size from 0 to n ...)
-

--- a/source/test-suite/test-dynamic-shape.lisp
+++ b/source/test-suite/test-dynamic-shape.lisp
@@ -139,3 +139,14 @@
               for expected = (proceed (scaled-dot-product-attention query key value))
               do (setf (tensor-shape symbolic) (tensor-shape expected))
                  (assert-equal () symbolic expected)))))
+
+(deftest symbolic-tensor-shaped-triu-test
+  (loop with n = (iconst 'n)
+        with s = (iconst 's)
+        with m = (caten (!triu (!full `(1 1 ,(!+ n s) ,s) (-inf)) :diagonal (!+ (iconst 1) n)))
+        for nn upfrom 10 below 13 do
+          (loop for ss upfrom 10 below 13
+                for symbolic = (forward m `(s . ,ss) `(n . ,nn))
+                for expected = (proceed (!triu (!full `(1 1 ,(+ nn ss) ,ss) (-inf)) :diagonal (+ 1 nn)))
+                do (setf (tensor-shape symbolic) (tensor-shape expected))
+                   (assert-equal () symbolic expected))))

--- a/source/test-suite/test-scheduler.lisp
+++ b/source/test-suite/test-scheduler.lisp
@@ -193,6 +193,7 @@
         (dolist (item (gather-kernels schedule))
           (let ((bp (caten/codegen/blueprint:print-blueprint (caten/codegen/blueprint:lower-schedule-item item (avm-graph avm) schedule) nil)))
             ;; Here, val_8=n must be passed as a uint64_t, not a poitner!
+            ;; If the dynamic shape is appeared across different kernels, without proper patching, the dynamic shape is loaded as a pointer which is unexpected.
             (ok
              (or
               (cl-ppcre:scan "val_8\\+_gid1" bp)  ;; todo: remove then if lowerer can fuse val_8=n


### PR DESCRIPTION
## Workload

- [ ] Improve the simplifying time for full symbolic
- [ ] CI: Benchmark is running with full symbolic
- [ ] Tests: having decent tests for full symbolic (for gemm, attention, etc...)
- [x] Repro and test for https://github.com/hikettei/Caten/issues/272
  - [x] dispatch :LOAD for each kernel
- [ ] NOOPT=1 produces a warning with Transformer?
- [x] Allocate for LOAD is not args
- [ ] fix for failing case