### PR TITLE
BugFix: JIT=1 should support !assign to get KVCache worked.

### DIFF
--- a/apps/gpt2/gpt2.lisp
+++ b/apps/gpt2/gpt2.lisp
@@ -90,9 +90,10 @@
            (start-pos 0)
            (max-length 100))
       (loop for i upfrom 0 below max-length
-            for out = (forward model `(x . ,(->input tokens)) `(s . ,(length tokens)) `(n . ,start-pos)) do
+            for in-tokens = (subseq tokens start-pos)
+            for out = (forward model `(x . ,(->input in-tokens)) `(s . ,(length in-tokens)) `(n . ,start-pos)) do
               (with-facet (out* (out :direction :simple-array))
-                (setf start-pos (length tokens)) ;; start_pos = previous_seq_len
+                (setf start-pos (length tokens)) ;; start_pos = previous_total_seq_len
                 (let ((size (array-total-size out*)))
                   (setf tokens (append tokens (list (aref out* (1- size)))))
                   (print tokens)

--- a/apps/gpt2/gpt2.lisp
+++ b/apps/gpt2/gpt2.lisp
@@ -72,7 +72,7 @@
   (declare (type keyword model-type))
   (assert (find model-type `(:gpt2 :gpt2-medium :gpt2-large :gpt2-xl)) () "model-type must be one of :gpt2, :gpt2-medium, :gpt2-large, :gpt2-xl")
   (with-inference-mode ()
-    (let* ((caten/llm::*use-kv-cache* nil) ;; todo: use kv-cache once segv is resolved.
+    (let* ((caten/llm::*use-kv-cache* t) ;; todo: use kv-cache once segv is resolved.
            (param (get-param model-type))
            (gguf (load-gguf-url (url model-type) (format nil "~(~a~)-f32.gguf" model-type)))
            (model (Transformer (params-dim param) (params-n-heads param) (params-n-layers param) (params-norm-eps param) (params-vocab-size param) :max-seq-len max-seq-len))
@@ -89,11 +89,11 @@
   (with-slots ((model model) (tokenizer tokenizer) (max-seq-len max-seq-len)) gpt2
     (let* ((tokens (encode tokenizer input))
            (start-pos 0)
-           (max-length 30))
+           (max-length 100))
       (loop for i upfrom 0 below max-length
             for out = (forward model `(x . ,(->input tokens)) `(s . ,(length tokens)) `(n . ,start-pos)) do
               (with-facet (out* (out :direction :simple-array))
-                (setf start-pos (length tokens))
+                (setf start-pos (length tokens)) ;; start_pos = previous_seq_len
                 (let ((size (array-total-size out*)))
                   (setf tokens (append tokens (list (aref out* (1- size)))))
                   (print tokens)

--- a/apps/gpt2/gpt2.lisp
+++ b/apps/gpt2/gpt2.lisp
@@ -72,8 +72,7 @@
   (declare (type keyword model-type))
   (assert (find model-type `(:gpt2 :gpt2-medium :gpt2-large :gpt2-xl)) () "model-type must be one of :gpt2, :gpt2-medium, :gpt2-large, :gpt2-xl")
   (with-inference-mode ()
-    (let* ((caten/llm::*use-kv-cache* t) ;; todo: use kv-cache once segv is resolved.
-           (param (get-param model-type))
+    (let* ((param (get-param model-type))
            (gguf (load-gguf-url (url model-type) (format nil "~(~a~)-f32.gguf" model-type)))
            (model (Transformer (params-dim param) (params-n-heads param) (params-n-layers param) (params-norm-eps param) (params-vocab-size param) :max-seq-len max-seq-len))
            (tokenizer (gguf->bpe-tokenizer gguf))

--- a/external/llm/layers.lisp
+++ b/external/llm/layers.lisp
@@ -22,8 +22,8 @@
   (multiple-value-bind (batch-size seq-len n-heads head-dim) (apply #'values (shape k))
     (assert (integerp batch-size) () "KVCache does not support a dynamic batch size")
     (let* ((max-len (attn-max-seq-len attn))
-           (k-cache (or (attn-k-cache attn) (linspace `(,batch-size ,max-len ,n-heads ,head-dim) 0 0 :id (gensym "K_CACHE"))))
-           (v-cache (or (attn-v-cache attn) (linspace `(,batch-size ,max-len ,n-heads ,head-dim) 0 0 :id (gensym "V_CACHE"))))
+           (k-cache (or (attn-k-cache attn) (linspace `(,batch-size ,max-len ,n-heads ,head-dim) 0 0)))
+           (v-cache (or (attn-v-cache attn) (linspace `(,batch-size ,max-len ,n-heads ,head-dim) 0 0)))
            (range1 (list start-pos (!+ start-pos (iconst seq-len))))
            (range2 (list 0 (!+ start-pos (iconst seq-len)))))
       (setf (attn-k-cache attn) k-cache

--- a/external/llm/layers.lisp
+++ b/external/llm/layers.lisp
@@ -28,8 +28,8 @@
            (range2 (list 0 (!+ start-pos (iconst seq-len)))))
       (setf (attn-k-cache attn) k-cache
             (attn-v-cache attn) v-cache)
-      (setf k-cache (!move (!view k-cache t range1 t t) k :reduce t)
-            v-cache (!move (!view v-cache t range1 t t) v :reduce t))
+      (setf k-cache (!assign (!view k-cache t range1 t t) k)
+            v-cache (!assign (!view v-cache t range1 t t) v))
       (values (!view-from-base k-cache t range2 t t) (!view-from-base v-cache t range2 t t)))))
 
 (defmethod call ((model Attention) &rest inputs)

--- a/external/llm/layers.lisp
+++ b/external/llm/layers.lisp
@@ -22,8 +22,8 @@
   (multiple-value-bind (batch-size seq-len n-heads head-dim) (apply #'values (shape k))
     (assert (integerp batch-size) () "KVCache does not support a dynamic batch size")
     (let* ((max-len (attn-max-seq-len attn))
-           (k-cache (or (attn-k-cache attn) (linspace `(,batch-size ,max-len ,n-heads ,head-dim) 0 0)))
-           (v-cache (or (attn-v-cache attn) (linspace `(,batch-size ,max-len ,n-heads ,head-dim) 0 0)))
+           (k-cache (or (attn-k-cache attn) (linspace `(,batch-size ,max-len ,n-heads ,head-dim) 0 0 :id (gensym "K_CACHE"))))
+           (v-cache (or (attn-v-cache attn) (linspace `(,batch-size ,max-len ,n-heads ,head-dim) 0 0 :id (gensym "V_CACHE"))))
            (range1 (list start-pos (!+ start-pos (iconst seq-len))))
            (range2 (list 0 (!+ start-pos (iconst seq-len)))))
       (setf (attn-k-cache attn) k-cache

--- a/source/apis/documentation.lisp
+++ b/source/apis/documentation.lisp
@@ -101,6 +101,7 @@ Compute the backward pass of the compiled computational graph (AVM). Note that t
     (def "!repeat" #'!repeat "(proceed (!repeat (ax+b `(1 10) 1 0) 10 1))")
     (def "!expand" #'!expand "(proceed (!expand (ax+b `(1 10) 1 0) `(10 10)))")
     (def "!move" #'!move "(proceed (!move (ax+b `(10 10) 0 0) (ax+b `(10 10) 0 2)))")
+    (def "!assign" #'!assign "(proceed (!assign (ax+b `(10 10) 0 0) (ax+b `(10 10) 0 2)))")
     (def "!add" #'!add "(proceed (!add (ax+b `(10 10) 1 0) (ax+b `(10 10) 1 0)))")
     (def "!sub" #'!sub "(proceed (!sub (ax+b `(10 10) 1 0) (ax+b `(10 10) 1 0)))")
     (def "!mul" #'!mul "(proceed (!mul (ax+b `(10 10) 1 0) (ax+b `(10 10) 1 0)))")

--- a/source/apis/function.lisp
+++ b/source/apis/function.lisp
@@ -337,7 +337,7 @@ Moves the element of b into a, returning a. If `reduce` is T, it will reduce the
 ```
 (!assign a b)
 ```
-Equivalent to doing `(!move a b :reduce t)`.
+Equivalent to doing `(!move a b :reduce t)`. Useful when you want to the value of lazy ops to an pre-allocated buffer, like KV-Cache.
 "
   (!move a b :reduce t))
 

--- a/source/apis/function.lisp
+++ b/source/apis/function.lisp
@@ -332,6 +332,15 @@ Moves the element of b into a, returning a. If `reduce` is T, it will reduce the
   (declare (type tensor a b))
   (apply #'forward (make-instance 'Move :reduction reduce) (broadcast-elwise a b)))
 
+(defun !assign (a b)
+  "
+```
+(!assign a b)
+```
+Equivalent to doing `(!move a b :reduce t)`.
+"
+  (!move a b :reduce t))
+
 (defclass Add (Func)
   ((reduce :initarg :reduce :initform nil :accessor func-reduce)
    (id :initarg :id :initform nil :accessor func-id)

--- a/source/apis/package.lisp
+++ b/source/apis/package.lisp
@@ -140,6 +140,7 @@
    #:!div #:!/
    #:!idiv
    #:!move
+   #:!assign
    #:!maximum #:!minimum
    #:!max #:!min
    #:!gcd #:!lcm

--- a/source/avm/lisp-backend.lisp
+++ b/source/avm/lisp-backend.lisp
@@ -75,7 +75,9 @@
 	    (progn
               (setf (buffer-value out) (copy-seq (buffer-value out)))
 	      (apply #'map-into/buffer out op `(,out ,@(cdr buffers)))
-	      (setf (buffer-value (car buffers)) (buffer-value out)))
+              (let ((base-elms (buffer-value (car buffers))))
+                (dotimes (i (array-total-size base-elms)) ;; synchronize the reduction to the original buffer.
+                  (setf (aref base-elms i) (aref (buffer-value out) i)))))
             (progn
               ;; If not reduced and the `out` is broadcasted?
               ;; In that case the output tensor should be a contiguous. (e.g: out[10, 10] = x[1] + y[10, 10])

--- a/source/codegen/scheduler.lisp
+++ b/source/codegen/scheduler.lisp
@@ -766,7 +766,7 @@ This function will put a copy of LOAD if some of nodes in group-items stop right
                ;; reduced but no users in the group: This is now allowed. Adding :MOVE
                (when (and (getattr node :reduction :allow-undefined t)
                           ;; write-to needs to be broadcasted.
-                          (some #'(lambda (x) (and x (fourth x))) (buffer-views (car (relay-writes (read-type-relay node)))))
+                          (node-writes-broadcasted-p node)
                           (null (id->users g (car (node-writes node))))) ;; no users in a group
                  (let ((base-id (car (node-reads node)))
                        (write-id (car (node-writes node)))

--- a/source/codegen/scheduler.lisp
+++ b/source/codegen/scheduler.lisp
@@ -765,6 +765,8 @@ This function will put a copy of LOAD if some of nodes in group-items stop right
              (dolist (node (graph-nodes g))
                ;; reduced but no users in the group: This is now allowed. Adding :MOVE
                (when (and (getattr node :reduction :allow-undefined t)
+                          ;; write-to needs to be broadcasted.
+                          (some #'(lambda (x) (and x (fourth x))) (buffer-views (car (relay-writes (read-type-relay node)))))
                           (null (id->users g (car (node-writes node))))) ;; no users in a group
                  (let ((base-id (car (node-reads node)))
                        (write-id (car (node-writes node)))

--- a/source/codegen/shape-inference.lisp
+++ b/source/codegen/shape-inference.lisp
@@ -77,7 +77,8 @@
    #:iteration-space-expr-aref
    #:buffer-iteration-space
    #:ensure-iteration-space-length
-   #:inferred-type-vizualize-to-dot))
+   #:inferred-type-vizualize-to-dot
+   #:node-writes-broadcasted-p))
 
 (in-package :caten/codegen/shape-inference)
 
@@ -413,3 +414,6 @@ gids corresponds for the loop idx in the kernel.
 (defmethod ensure-iteration-space-length ((rank fixnum) gids)
   (let ((pads (loop repeat (max 0 (- rank (length gids))) collect (expr-const 0 :int64))))
     (append gids pads)))
+
+(defun node-writes-broadcasted-p (node)
+  (some #'(lambda (x) (and x (fourth x))) (buffer-views (car (relay-writes (read-type-relay node))))))

--- a/source/test-suite/test-llm.lisp
+++ b/source/test-suite/test-llm.lisp
@@ -381,13 +381,13 @@ def attn_impl_torch(x, n_heads, c_attn_weight, c_attn_bias, c_proj_weight, c_pro
   (with-no-grad
     (when (= 1 (ctx:getenv :JIT))
       (testing "No Segv?"
-        (let* ((caten/llm::*use-kv-cache* nil) ;; *use-kv-cache*=T will also cause segfault
+        (let* ((caten/llm::*use-kv-cache* nil)
                (model (Transformer 32 4 2 1e-5 32))
                (x (forward model (make-tensor `(1 s) :from 'x) (iconst 'n)))
                (model (caten x)))
           (let ((value (forward model `(x . ,(randint `(1 3) :low 0 :high 10)) `(s . 3) `(n . 0))))
             (ok value (format nil "~a" value))))))))
-;; Failing for now (TODO: Fix)
+
 #|
 (deftest test-symbolic-transformer-forward-test-1-layer
   (with-no-grad
@@ -397,6 +397,7 @@ def attn_impl_torch(x, n_heads, c_attn_weight, c_attn_bias, c_proj_weight, c_pro
              (x (forward model (make-tensor `(1 s) :from 'x) (iconst 'n)))
              (model (caten x)))
         (ok (forward model `(x . ,(randint `(1 3) :low 0 :high 10)) `(s . 3) `(n . 0)))))))
+|#
 
 (deftest test-symbolic-transformer-forward-test-2-layer
   (with-no-grad
@@ -407,4 +408,3 @@ def attn_impl_torch(x, n_heads, c_attn_weight, c_attn_bias, c_proj_weight, c_pro
                (x (forward model (make-tensor `(1 s) :from 'x) (iconst 'n)))
                (model (caten x)))
           (ok (forward model `(x . ,(randint `(1 3) :low 0 :high 10)) `(s . 3) `(n . 0))))))))
-|#

--- a/source/test-suite/test-ops.lisp
+++ b/source/test-suite/test-ops.lisp
@@ -53,8 +53,7 @@
 ;; [TODO] Binary Ops Test
 ;; [TODO] Reduce Ops Test
 (deftest test-assign
-  (let* ((x (linspace `(10 10) 0 0 :id 'place))
+  (let* ((x (linspace `(10 10) 0 0))
          (y (!assign x (fconst 1.0))))
     (proceed y)
     (ok (every #'(lambda (elm) (= elm 1.0)) (elements x)))))
-

--- a/source/test-suite/test-ops.lisp
+++ b/source/test-suite/test-ops.lisp
@@ -52,3 +52,9 @@
   )
 ;; [TODO] Binary Ops Test
 ;; [TODO] Reduce Ops Test
+(deftest test-assign
+  (let* ((x (linspace `(10 10) 0 0 :id 'place))
+         (y (!assign x (fconst 1.0))))
+    (proceed y)
+    (ok (every #'(lambda (elm) (= elm 1.0)) (elements x)))))
+

--- a/source/test-suite/test-scheduler.lisp
+++ b/source/test-suite/test-scheduler.lisp
@@ -201,6 +201,49 @@
               (cl-ppcre:scan "n\\+_gid1" bp)
               (cl-ppcre:scan "val_55\\+n" bp))
              (format nil "Rendererd:~%~a" bp))))))))
+
+(deftest test-assign-schedule
+  (with-no-grad
+    (multiple-value-bind (schedule avm) (schedule-with-vars (!assign (make-tensor `(3 3) :from 'a) (make-tensor `(3 3) :from 'b)))
+      (check-kernel schedule 1)
+      (caten/codegen/expr-cache:with-expr-cache ()
+        (dolist (item (gather-kernels schedule))
+          (let ((bp (caten/codegen/blueprint:lower-schedule-item item (avm-graph avm) schedule)))
+            ;; MoveAfterReduction rule should not applied here.
+            (ok (= 1 (count :EXPR bp :key #'node-type)))))))))
+
+(defun make-k-cache-kernel ()
+  (let* ((batch-size 1) (max-context-len 128) (n-heads 4) (head-dim 4)
+         (k-cache-data (linspace `(,batch-size ,max-context-len ,n-heads ,head-dim) 0 0 :id 'k_cache_data))
+         (start-pos (iconst 'start_pos))
+         (seq-len   (iconst 'seq_len))
+         (range1 (list start-pos (!+ start-pos seq-len)))
+         (range2 (list 0 (!+ start-pos seq-len)))
+         (k (make-tensor `(,batch-size ,seq-len ,n-heads ,head-dim) :from 'k :id 'k_input))
+         (k-cache (!assign (!view k-cache-data t range1 t t) k))
+         (k-cache (!copy (!view-from-base k-cache t range2 t t))))
+    k-cache))
+
+(deftest test-k-cache-schedule
+  (with-no-grad
+    (multiple-value-bind (schedule avm) (schedule-with-vars (make-k-cache-kernel))
+      (check-kernel schedule 2)
+      (caten/codegen/expr-cache:with-expr-cache ()
+        (dolist (item (gather-kernels schedule))
+          (let ((bp (caten/codegen/blueprint:lower-schedule-item item (avm-graph avm) schedule)))
+            ;; Assume the first one is a reduce, the second one is contiguous.
+            (if (find-if #'(lambda (x) (getattr x :reduction :allow-undefined t)) (getattr item :items))
+                (let ((expr (find :EXPR bp :key #'node-type)))
+                  (ok (= 1 (count :EXPR bp :key #'node-type))
+                      (format nil "Expected 1 reduction, got ~a" (count :EXPR bp :key #'node-type)))
+                  (ok (equal (node-writes expr) `(K_CACHE_DATA)))
+                  (ok (equal (node-reads expr) `(K_INPUT))))
+                (let ((expr (find :EXPR bp :key #'node-type)))
+                  (ok (= 1 (count :EXPR bp :key #'node-type))
+                      (format nil "Expected 1 contiguous, got ~a" (count :EXPR bp :key #'node-type)))
+                  (let* ((read-type (car (caten/codegen/shape-inference:relay-read-iters (caten/codegen/shape-inference:read-type-relay expr)))))
+                    (ok (every #'(lambda (x) (or (null x) (eql 0 (car x)))) (caten/codegen/shape-inference:iteration-space-views read-type))
+                        "The second kernel should not create a offset for rhs."))))))))))
 ;;TODO:  ConvND batch_size=1
 ;; ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ;;


### PR DESCRIPTION
## Workload

- [x] Applying the MoveAfterReduction rule only after the write buffer is broadcasted.
- [ ] ~~Force realize at !view-from-base~~ no its just type inference problem
- [x] New Ops !assign
- [x] !assign test
- [x] JIT=1 support !assign.
- [x] !assign with dynamic shape (K-Cache-test)
- [x] Scheduling Test, to confirm moveafterreduction is not applied
- [x] KVCache to work
- [ ] `caten/llm:*max-context-len*`
- [ ] GPT to work?
- [x] Test GPT2 before merging