### PR TITLE
Use `qlot` and `ros` for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ install_docs: ## Install documentation dependencies
 
 .PHONY: build_docs
 build_docs: ## Build documentation
-	./roswell/caten.ros docs
+	$(join $(PROJECT_ROOT),roswell/caten.ros) docs
 
 .PHONY: serve_docs
 serve_docs: ## Serve documentation

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+PROJECT_ROOT  := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+QLOT          := qlot
 ROSWELL       := ros
-QUICKLOAD     := --eval '(progn (cl:push (cl:pathname "./") ql:*local-project-directories*) (asdf:load-asd "caten.asd") (ql:quickload "caten" :silent t))'
 PIP           := pip
 
 .PHONY: help
@@ -13,7 +14,11 @@ install_extra: ## Install extra dependencies for testing
 
 .PHONY: test
 test: ## Runs test harness
-	$(ROSWELL) $(QUICKLOAD) --eval '(asdf:test-system "caten")'
+	$(QLOT) exec $(ROSWELL) run \
+		--source-registry $(PROJECT_ROOT) \
+		--eval '(ql:quickload "caten/test")' \
+		--eval '(asdf:test-system "caten/test")'\
+		--quit
 
 .PHONY: install_docs
 install_docs: ## Install documentation dependencies


### PR DESCRIPTION
- **BugFix: use qlot and roswell for testing**
- **BugFix: use absolute path for running roswell script**

* Caluculate and use absolute path of the directory containing the `Makefile`.
* Use the `--source-registry` option of the `ros` command for consistency instead of manupilating Quicklisp variables manually
