### PR TITLE
enable (simple) loading of Caten via the REPL/Slime (without using ros)

### DIFF
--- a/asdf-load-caten.lisp
+++ b/asdf-load-caten.lisp
@@ -1,0 +1,8 @@
+(in-package :cl-user)
+
+(asdf:initialize-source-registry
+ `(:source-registry (:tree ,(directory-namestring
+			     (or *load-pathname* *compile-file-pathname*)))
+   :inherit-configuration))
+
+(ql:quickload :caten)


### PR DESCRIPTION
This adds asdf-load-caten.lisp which enables just loading Caten from Slime, the REPL, etc. without using ros.