### PR TITLE
Full Symbolic Loop Collapse

### DIFF
--- a/source/apis/helpers.lisp
+++ b/source/apis/helpers.lisp
@@ -230,3 +230,20 @@ Reads and binds attributes from module.
     (setf (nth idx list) value)))
 
 (defmethod permute-list ((op list) list) (loop for nth in op collect (nth nth list)))
+
+(defun sym-eql (a b)
+  (if (and (tensor-p a) (tensor-p b))
+      (or
+       (eql a b)
+       (let* ((g1 (with-no-grad (tensor-lowered-graph a)))
+              (g2 (with-no-grad (tensor-lowered-graph b)))
+              (g1 (caten/codegen/expr:make-expr :graph g1 :out (car (last (graph-nodes g1)))))
+              (g2 (caten/codegen/expr:make-expr :graph g2 :out (car (last (graph-nodes g2))))))
+         ;; Note(hikettei) this could be ridiculously slow if the shape is determined by the tensor!
+         ;; Especially in the ViT Graph
+         (caten/codegen/expr:expr-scalar-equivalent-p g1 g2)))
+      (equal a b)))
+
+(defun sym-equal (a b)
+  (declare (type list a b))
+  (and (= (length a) (length b)) (every #'sym-eql a b)))

--- a/source/apis/merge-views.lisp
+++ b/source/apis/merge-views.lisp
@@ -329,7 +329,7 @@ for i in range(3):
           (loop for m in (make-broadcast-mask (tr-shape tracker) new-shape)
                 for s in new-shape
                 if m collect s)))
-    (when (equal shape-w/o-one (tr-shape tracker))
+    (when (sym-equal shape-w/o-one (tr-shape tracker))
       (return-from tr-reshapeable-p t)))
   (when (apply-masked-reshape tracker new-shape)
     (return-from tr-reshapeable-p t))
@@ -351,7 +351,7 @@ for i in range(3):
            (loop for m in mask
                  for s in new-shape
                  if m collect s)))
-    (when (equal shape-w/o-one (tr-shape tracker))
+    (when (sym-equal shape-w/o-one (tr-shape tracker))
       (return-from tr-apply-reshape (tr-apply-uprank tracker mask))))
   (assert (equal (tr-permute tracker) (range 0 (length (tr-shape tracker)))) () "Trying to reshape the permuted tracker!")
   (let ((r (apply-masked-reshape tracker new-shape)))

--- a/source/codegen/shape-inference.lisp
+++ b/source/codegen/shape-inference.lisp
@@ -289,7 +289,7 @@ If the shape inference is successfully done and properly deployed to the target 
     (if (or (numberp val) (null (id->value graph val)))
         (expr-const val dtype)
         ;; Merge only scalar path!
-        (expr-from-graph val (apply #'caten/air:make-graph (graph-nodes graph))))))
+        (expr-from-graph val (apply #'caten/air:make-graph (gather-only-scalars (graph-nodes graph)))))))
 
 (defstruct Iteration-Space
   "

--- a/source/test-suite/test-schedule-cache.lisp
+++ b/source/test-suite/test-schedule-cache.lisp
@@ -81,7 +81,7 @@ Code2:
           for tf = (avm-graph (ctx:with-contextvar (:NO_SCHEDULE_CACHE 0) (compile-transformer i)))
           ;; [TODO] The number of kernels should be a constant regardless of layers!!
           do (ok (<= (count-compiled-kernels tf) expected)
-                 (format nil "(Currently Failing ...) Compiled ~a kernels (expecting ~a)" (count-compiled-kernels tf) expected)))))
+                 (format nil "Compiled ~a kernels (expecting ~a)" (count-compiled-kernels tf) expected)))))
 
 (deftest transformer-schedule-cache-consistency-test
   (with-protect-jit

--- a/source/test-suite/test-schedule-cache.lisp
+++ b/source/test-suite/test-schedule-cache.lisp
@@ -77,7 +77,7 @@ Code2:
 (deftest transformer-schedule-cache-count-test
   (with-protect-jit
     (loop for i upfrom 1 below 6
-          for expected in `(16 20 23 26 29)
+          for expected in `(14 18 21 24 27)
           for tf = (avm-graph (ctx:with-contextvar (:NO_SCHEDULE_CACHE 0) (compile-transformer i)))
           ;; [TODO] The number of kernels should be a constant regardless of layers!!
           do (ok (<= (count-compiled-kernels tf) expected)

--- a/source/test-suite/test-scheduler.lisp
+++ b/source/test-suite/test-scheduler.lisp
@@ -63,7 +63,7 @@
               for count in `(1) do
                 (let ((bp (caten/codegen/blueprint:lower-schedule-item item (avm-graph avm) schedule)))
                   (ok (= count (count :FOR bp :key #'node-type)) (format nil "Expected ~a loops, got ~a" count (count :FOR bp :key #'node-type))))))))
-  (testing "Softmax Batch Collapse"
+  (testing "Softmax Batch=Tensor"
     (multiple-value-bind (schedule avm) (schedule-with-vars (!softmax (make-tensor `(,(!add (iconst 'n) (iconst 's)) n s))))
       (check-kernel schedule 1)
             (caten/codegen/expr-cache:with-expr-cache ()

--- a/source/test-suite/test-scheduler.lisp
+++ b/source/test-suite/test-scheduler.lisp
@@ -66,7 +66,7 @@
   (testing "Softmax Batch=Tensor"
     (multiple-value-bind (schedule avm) (schedule-with-vars (!softmax (make-tensor `(,(!add (iconst 'n) (iconst 's)) n s))))
       (check-kernel schedule 1)
-            (caten/codegen/expr-cache:with-expr-cache ()
+      (caten/codegen/expr-cache:with-expr-cache ()
         (loop for item in (gather-kernels schedule)
               for count in `(4) do
                 (let ((bp (caten/codegen/blueprint:lower-schedule-item item (avm-graph avm) schedule)))

--- a/source/test-suite/test-scheduler.lisp
+++ b/source/test-suite/test-scheduler.lisp
@@ -62,6 +62,22 @@
         (loop for item in (gather-kernels schedule)
               for count in `(1) do
                 (let ((bp (caten/codegen/blueprint:lower-schedule-item item (avm-graph avm) schedule)))
+                  (ok (= count (count :FOR bp :key #'node-type)) (format nil "Expected ~a loops, got ~a" count (count :FOR bp :key #'node-type))))))))
+  (testing "Softmax Batch Collapse"
+    (multiple-value-bind (schedule avm) (schedule-with-vars (!softmax (make-tensor `(,(!add (iconst 'n) (iconst 's)) n s))))
+      (check-kernel schedule 1)
+            (caten/codegen/expr-cache:with-expr-cache ()
+        (loop for item in (gather-kernels schedule)
+              for count in `(4) do
+                (let ((bp (caten/codegen/blueprint:lower-schedule-item item (avm-graph avm) schedule)))
+                  (ok (= count (count :FOR bp :key #'node-type)) (format nil "Expected ~a loops, got ~a" count (count :FOR bp :key #'node-type))))))))
+  (testing "Matmul Batch=Tensor"
+    (multiple-value-bind (schedule avm) (schedule-with-vars (!matmul (make-tensor `(,(!add (iconst 'a) (iconst 'b)) 512 256)) (make-tensor `(256 1024))))
+      (check-kernel schedule 1)
+      (caten/codegen/expr-cache:with-expr-cache ()
+        (loop for item in (gather-kernels schedule)
+              for count in `(3) do
+                (let ((bp (caten/codegen/blueprint:lower-schedule-item item (avm-graph avm) schedule)))
                   (ok (= count (count :FOR bp :key #'node-type)) (format nil "Expected ~a loops, got ~a" count (count :FOR bp :key #'node-type)))))))))
 
 (deftest test-serialize-reduction-loop


### PR DESCRIPTION
#359 
- [x] writing a test
- [ ] outermost loop is the best loop to parallelize
- [x] Reduction (Softmax/LayerNorm/Argmax) cannot be parallelized with batch_size=1 right? (or reduction directive is needed?)
- [ ] Matmul can be parallelized

```
(caten (!softmax (make-tensor `(,(!add (iconst 'n) (iconst 's)) n s))))
(caten (!matmul (make-tensor `(,(!add (iconst 'a) (iconst 'b)) 512 256)) (make-tensor `(256 1024))))
(with-inference-mode ()
                    (caten (!add (call (Embedding 10 10) (make-tensor `(10 10))) (call (Embedding 10 10) (!cast (!add (iconst 'n) (!index-components `(1 10))) :float32)))))

(with-inference-mode ()
                    (caten (!add (call (Embedding 10 10) (make-tensor `(10 10))) (call (Embedding 10 10) (make-tensor `(1 10))))))
(caten (!matmul (make-tensor `(1 s 64)) (!t (make-tensor `(128 64)))))
```

- [x] ShapeTracker: should have an ability to prove `A+B == A+B`