### PR TITLE
Refactor: one device corresponds to one backend

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,7 +62,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           qlot install
-          CI=1 mkdir -p docs/packages && qlot exec make build_docs && echo -e "markdown-katex\nlantana==2.11.2" > docs/requirements.txt
+          mkdir -p docs/packages && CI=1 JIT=0 qlot exec make build_docs && echo -e "markdown-katex\nlantana==2.11.2" > docs/requirements.txt
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:

--- a/.github/workflows/tests_on_push.yml
+++ b/.github/workflows/tests_on_push.yml
@@ -119,4 +119,4 @@ jobs:
           qlot install
           qlot exec make install_docs
       - name: Building documentations
-        run: CI=1 mkdir -p docs/packages && make build_docs
+        run: CI=1 JIT=0 mkdir -p docs/packages && make build_docs

--- a/.github/workflows/tests_on_push.yml
+++ b/.github/workflows/tests_on_push.yml
@@ -119,4 +119,4 @@ jobs:
           qlot install
           qlot exec make install_docs
       - name: Building documentations
-        run: CI=1 JIT=0 mkdir -p docs/packages && make build_docs
+        run: CI=1 mkdir -p docs/packages && make build_docs

--- a/.github/workflows/tests_on_push.yml
+++ b/.github/workflows/tests_on_push.yml
@@ -119,4 +119,4 @@ jobs:
           qlot install
           qlot exec make install_docs
       - name: Building documentations
-        run: CI=1 mkdir -p docs/packages && make build_docs
+        run: mkdir -p docs/packages && CI=1 JIT=0 make build_docs

--- a/source/apis/helpers.lisp
+++ b/source/apis/helpers.lisp
@@ -124,65 +124,6 @@ Reads and binds attributes from module.
 (defmacro range (from below &optional (by 1))
   `(loop for i from ,from below ,below by ,by collect i))
 
-(defun render-list (list) (apply #'concatenate 'string (butlast (loop for n in list append (list (format nil "~a" n) ", ")))))
-
-(defun render-attrs (node)
-  (let ((attr (dump-into-list (node-attr node) :allow-unbound nil)))
-    (if attr
-	(with-output-to-string (out)
-	  (dolist (k (getattrs node))
-	    (when k
-	      (format out ", ~(~a~)=~a" k (getattr node k)))))
-	"")))
-
-(defun avm-gather-args (avm)
-  (declare (type avm avm))
-  (remove-duplicates
-   (loop for node in (graph-nodes (avm-graph avm))
-	 if (and (eql (node-type node) :Load) (getattr node :value) (symbolp (getattr node :value)))
-	   collect (getattr node :value))))
-
-(defun print-avm (avm &key (stream t) (n-indent 4) (args nil) &aux (graph (avm-graph avm)))
-  "Utils for debugging the graph on the repl."
-  (declare (type avm avm))
-  (macrolet ((indent (n) `(with-output-to-string (out) (dotimes (i ,n) (princ " " out)))))
-    (format
-     stream
-     "~a"
-     (with-output-to-string (out)
-       (format out "~%~adefun ~(~a~)(~(~a~))~%" (indent (- n-indent 4)) (avm-name avm) (render-list (append args (reverse (avm-gather-args avm)))))
-       (loop for node in (graph-nodes graph)
-	     if (eql (node-type node) :Allocate) do
-	       (let ((nrank (getattr node :nrank)))
-		 (format out "~a~(~a~) = ~(~a~)(shape=(~a), stride=(~a)~a);~%"
-			 (indent n-indent)
-			 (render-list (node-writes node))
-			 (node-type node)
-			 (render-list (subseq (node-reads node) 0 nrank))
-			 (render-list (subseq (node-reads node) nrank))
-			 (render-attrs node)))
-	     else if (eql (Node-type node) :View) do
-	       (let ((nrank (getattr node :nrank)))
-		 (flet ((subseq1p (x y z) (subseq x (1+ y) (1+ z))))
-		   (format out "~a~(~a~) = ~(~a~)(~(~a~), shape=(~a), views=(~a), stride=(~a)~a);~%"
-			   (indent n-indent)
-			   (render-list (node-writes node))
-			   (node-type node)
-			   (car (node-reads node))
-			   (render-list (subseq1p (node-reads node) 0 nrank))
-			   (let ((upfrom (subseq1p (node-reads node) nrank (* 2 nrank)))
-				 (below (subseq1p (node-reads node) (* 2 nrank) (* 3 nrank)))
-				 (by (subseq1p (node-reads node) (* 3 nrank) (* 4 nrank)))
-				 (bc (getattr node :broadcast)))
-			     (render-list
-			      (map 'list #'(lambda (x y z l) (format nil "(~a)" (render-list (list x y z l)))) upfrom below by bc)))
-			   (render-list (subseq1p (node-reads node) (* 4 nrank) (* 5 nrank)))
-			   (if (getattr node :permute)
-			       (format nil ", permute=~a" (getattr node :permute))
-			       ""))))
-	     else
-	       do (format out "~a~(~a~)~a~(~a~)(~(~a~)~a);~%" (indent n-indent) (render-list (node-writes node)) (if (node-writes node) " = " "") (node-type node) (render-list (node-reads node)) (render-attrs node)))))))
-
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defun collect-initargs-names (args)
     (loop for a in args

--- a/source/apis/package.lisp
+++ b/source/apis/package.lisp
@@ -122,7 +122,6 @@
   (:export
    #:with-no-grad
    #:with-attrs
-   #:print-avm
    #:normalize-axis
    #:normalize-axes)
   ;; from iseq.lisp

--- a/source/avm/buffer.lisp
+++ b/source/avm/buffer.lisp
@@ -6,7 +6,8 @@
 (defmacro with-device (device &body body)
   "declares the device to use"
   `(let ((*device* ,device)) ,@body))
-
+;; [TODO]
+;; make-buffer?
 (defstruct (Buffer
 	    (:constructor make-buffer (nrank shape stride dtype views)))
   (value nil)

--- a/source/avm/helpers.lisp
+++ b/source/avm/helpers.lisp
@@ -47,3 +47,13 @@
   (ecase *default-order*
     (:row (row-major-calc-strides shape))
     (:column (column-major-calc-strides shape))))
+
+(defun make-hash-table-from-params (params)
+  (declare (type list params))
+  (let ((out (make-hash-table :test #'eql)))
+    (loop for (k . v) in params
+	  do (setf (gethash k out) v))
+    ;; Constants
+    (setf (gethash t out) t
+	  (gethash nil out) :nil)
+    out))

--- a/source/avm/helpers.lisp
+++ b/source/avm/helpers.lisp
@@ -57,3 +57,5 @@
     (setf (gethash t out) t
 	  (gethash nil out) :nil)
     out))
+
+(defun render-list (list) (apply #'concatenate 'string (butlast (loop for n in list append (list (format nil "~a" n) ", ")))))

--- a/source/avm/package.lisp
+++ b/source/avm/package.lisp
@@ -34,7 +34,7 @@
   ;; from runtime.lisp
   (:export
    #:AVM
-   #:make-avm #:avm-graph #:avm-name #:avm-fw-outputs #:avm-bw-outputs #:copy-avm #:deepcopy-avm
+   #:make-avm #:avm-graph #:avm-name #:avm-fw-outputs #:avm-bw-outputs #:avm-backend #:avm-device
    #:avm-id2tensor #:avm-tape-length #:avm-pc #:avm-variables #:avm-params-to-optimize
    #:*vm*
    #:%realize

--- a/source/avm/runtime.lisp
+++ b/source/avm/runtime.lisp
@@ -125,7 +125,7 @@
         (let ((t1 (get-internal-real-time))
               (out (multiple-value-list
 		    (handler-bind ((error #'(lambda (cond) (error 'avm-runtime-error :avm avm :cond cond))))
-		      (%impl avm type (avm-graph avm) node (map 'list #'->real reads)))))
+		      (%impl *device* type (avm-graph avm) node (map 'list #'->real reads)))))
               (t2 (get-internal-real-time)))
 	  (assert (or (null writes) (= (length out) (length writes))) () "The length of output ~a does not match ~a" out node)
           (when (= 1 (ctx:getenv :PROFILE))

--- a/source/avm/runtime.lisp
+++ b/source/avm/runtime.lisp
@@ -1,6 +1,6 @@
 (in-package :caten/avm)
-(defparameter *vm* nil)
-(defgeneric %impl (device op graph node args) (:documentation "Peforms the corresponding nodes"))
+
+(defparameter *vm* nil "Binds to the AVM object currently running.")
 
 (defun make-hash-table-from-params (params)
   (declare (type list params))
@@ -11,6 +11,7 @@
     (setf (gethash t out) t
 	  (gethash nil out) :nil)
     out))
+
 (defstruct (AVM
 	    (:constructor make-avm (graph name id2tensor fw-outputs bw-outputs &optional params (dumped nil)
                                           &aux

--- a/source/avm/runtime.lisp
+++ b/source/avm/runtime.lisp
@@ -2,35 +2,76 @@
 
 (defparameter *vm* nil "Binds to the AVM object currently running.")
 
-(defun make-hash-table-from-params (params)
-  (declare (type list params))
-  (let ((out (make-hash-table :test #'eql)))
-    (loop for (k . v) in params
-	  do (setf (gethash k out) v))
-    ;; Constants
-    (setf (gethash t out) t
-	  (gethash nil out) :nil)
-    out))
+(defclass AVM ()
+  ((graph :initarg :graph :accessor avm-graph)
+   (name :initarg :name :accessor avm-name)
+   (fw-outputs :initarg :fw-outputs :accessor avm-fw-outputs)
+   (bw-outputs :initarg :bw-outputs :accessor avm-bw-outputs)
+   (id2tensor :initarg :id2tensor :accessor avm-id2tensor) ;; Node ID -> Tensor
+   (tape-length :initarg :tape-length :accessor avm-tape-length)
+   (pc :initform 0 :accessor avm-pc)
+   (variables :initform (make-hash-table) :initarg :variables :accessor avm-variables)
+   (params-to-optimize :initform nil :accessor avm-params-to-optimize)
+   (dumped :initform nil :initarg :dumped :accessor avm-dumped)))
 
-(defstruct (AVM
-	    (:constructor make-avm (graph name id2tensor fw-outputs bw-outputs &optional params (dumped nil)
-                                          &aux
-                                          (id2tensor (or id2tensor (make-hash-table)))
-                                            (_
-                                             (when (null (graph-outputs graph))
-                                               (setf (graph-outputs graph) (append fw-outputs bw-outputs)))))))
-  "Tape based iseq executor"
-  (graph graph :type graph)
-  (name name :type keyword)
-  (fw-outputs fw-outputs :type list)
-  (bw-outputs bw-outputs :type list)
-  (id2tensor id2tensor :type hash-table)
-  (tape-length (length (graph-nodes graph)) :type fixnum)
-  (pc 0 :type fixnum)
-  (variables (make-hash-table-from-params params) :type hash-table)
-  (params-to-optimize nil :type list)
-  (dumped dumped :type boolean)) ;; If dumped: CLOS objects are removed which is unnecessary to reconstruct the executable graph.
+(defun make-avm (graph name id2tensor fw-outputs bw-outputs &optional params (dumped nil))
+  (when (null (graph-outputs graph))
+    (setf (graph-outputs graph) (append fw-outputs bw-outputs)))
+  (make-instance 'AVM ;; TODO: Different Backend uses different AVM
+                 :graph graph :name name :id2tensor (or id2tensor (make-hash-table))
+                 :fw-outputs fw-outputs :bw-outputs bw-outputs
+                 :tape-length (length (graph-nodes graph))
+                 :variables (make-hash-table-from-params params)
+                 :dumped dumped))
 
+(defmethod avm-gather-args ((avm avm))
+  (remove-duplicates
+   (loop for node in (graph-nodes (avm-graph avm))
+	 if (and (eql (node-type node) :Load) (getattr node :value) (symbolp (getattr node :value)))
+	   collect (getattr node :value)
+         else if (and (eql (node-type node) :Allocate) (getattr node :from) (symbolp (getattr node :from)))
+                collect (getattr node :from))))
+
+(defun render-list (list) (apply #'concatenate 'string (butlast (loop for n in list append (list (format nil "~a" n) ", ")))))
+
+(defmethod print-object ((avm AVM) stream &aux (n-indent 4))
+  (print-unreadable-object (avm stream :type t)
+    (format stream "{~a: ~(~a~) -> (~(~a~), ~(~a~))}~%" (avm-name avm) (avm-gather-args avm) (avm-fw-outputs avm) (avm-bw-outputs avm))
+    (macrolet ((indent (n) `(with-output-to-string (out) (dotimes (i ,n) (princ " " out)))))
+      (loop for node in (graph-nodes (avm-graph avm))
+            if (eql (Node-type node) :Allocate) do
+              (let ((nrank (getattr node :nrank)))
+                (format stream "~a~(~a~) = ~(~a~)(shape=(~a), stride=(~a)~a);~%" (indent n-indent) (render-list (node-writes node))
+			(node-type node) (render-list (subseq (node-reads node) 0 nrank)) (render-list (subseq (node-reads node) nrank))
+                        (if (getattr node :from)
+                            (if (symbolp (getattr node :from)) (format nil ", from=~a" (getattr node :from)) (format nil ", from=<Realized Buffer>"))
+                            "")))
+ 	    else if (eql (Node-type node) :View) do
+	      (let ((nrank (getattr node :nrank)))
+		(flet ((subseq1p (x y z) (subseq x (1+ y) (1+ z))))
+		   (format stream "~a~(~a~) = ~(~a~)(~(~a~), shape=(~a), views=(~a), stride=(~a)~a);~%"
+			   (indent n-indent)
+			   (render-list (node-writes node))
+			   (node-type node)
+			   (car (node-reads node))
+			   (render-list (subseq1p (node-reads node) 0 nrank))
+			   (let ((upfrom (subseq1p (node-reads node) nrank (* 2 nrank)))
+				 (below (subseq1p (node-reads node) (* 2 nrank) (* 3 nrank)))
+				 (by (subseq1p (node-reads node) (* 3 nrank) (* 4 nrank)))
+				 (bc (getattr node :broadcast)))
+			     (render-list
+			      (map 'list #'(lambda (x y z l) (format nil "(~a)" (render-list (list x y z l)))) upfrom below by bc)))
+			   (render-list (subseq1p (node-reads node) (* 4 nrank) (* 5 nrank)))
+			   (if (getattr node :permute)
+			       (format nil ", permute=~a" (getattr node :permute))
+			       ""))))
+	     else
+	       do (format stream "~a~(~a~)~a~(~a~)(~(~a~));~%" (indent n-indent) (render-list (node-writes node)) (if (node-writes node) " = " "")
+                          (if (eql (node-type node) :JIT_KERNEL)
+                              (uiop:symbol-call :caten/codegen/jit :compiled-kernel-name (getattr node :kernel-info))
+                              (node-type node))
+                          (render-list (node-reads node)))))))
+;; ~~~ TODO:Refactor~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defmethod make-load-form ((avm AVM) &optional env)
   (declare (ignore env))
   `(make-avm

--- a/source/avm/runtime.lisp
+++ b/source/avm/runtime.lisp
@@ -107,7 +107,7 @@
 
 (defun vm/step (avm &aux (*vm* avm))
   (declare (type avm avm))
-  (let ((node (nth (avm-pc avm) (graph-nodes (avm-graph avm)))))
+  (let ((node (nth (avm-pc avm) (graph-nodes (avm-graph avm)))) (*device* (or (avm-backend avm) *device*)))
     (declare (type node node))
     (flet ((->real (x)
 	     (if (symbolp x)

--- a/source/avm/runtime.lisp
+++ b/source/avm/runtime.lisp
@@ -13,9 +13,8 @@
    (variables :initform (make-hash-table) :initarg :variables :accessor avm-variables)
    (params-to-optimize :initform nil :accessor avm-params-to-optimize)
    (dumped :initform nil :initarg :dumped :accessor avm-dumped)
-   (device :initform 'AVM :accessor avm-device)))
-
-(defclass Relay-Checker (AVM) nil)
+   (device :initarg :device :accessor avm-device)
+   (backend :initform nil :accessor avm-backend)))
 
 (defun make-avm (graph name id2tensor fw-outputs bw-outputs &optional params (dumped nil) (device 'AVM))
   (when (null (graph-outputs graph))
@@ -26,7 +25,7 @@
    :fw-outputs fw-outputs :bw-outputs bw-outputs
    :tape-length (length (graph-nodes graph))
    :variables (make-hash-table-from-params params)
-   :dumped dumped))
+   :dumped dumped :device device))
 
 (defmethod avm-gather-args ((avm avm))
   (remove-duplicates
@@ -38,7 +37,7 @@
 
 (defmethod print-object ((avm AVM) stream &aux (n-indent 4))
   (print-unreadable-object (avm stream :type t)
-    (format stream "{~a: ~(~a~) -> (~(~a~), ~(~a~))}~%" (avm-name avm) (avm-gather-args avm) (avm-fw-outputs avm) (avm-bw-outputs avm))
+    (format stream "{~a[~a]: ~(~a~) -> (~(~a~), ~(~a~))}~%" (avm-name avm) (or (avm-backend avm) *device*) (avm-gather-args avm) (avm-fw-outputs avm) (avm-bw-outputs avm))
     (macrolet ((indent (n) `(with-output-to-string (out) (dotimes (i ,n) (princ " " out)))))
       (loop for node in (graph-nodes (avm-graph avm))
             if (eql (Node-type node) :Allocate) do

--- a/source/common/contextvar.lisp
+++ b/source/common/contextvar.lisp
@@ -139,7 +139,7 @@ Usage:
      1 :int #.(oneof "AUTO_SCHEDULER" 1 `(0 1))
      "Set to 1 to optimize using caten/codegen/polyhedral during JIT execution.")
     (:JIT
-     0 :int identity
+     1 :int identity
      "Set to 1 to run the graph with the JIT codegen.")
     (:JIT_BACKEND
      "CLANG" :string


### PR DESCRIPTION
- [ ] DEVICE=VM, DEVICE=CLANG, ... is the only way to switch the device.
  - [ ] Update docs
  - [ ] Update tests
- [x] AVM is a CLOS class.
  - Backend is determined the moment users called caten
  - Each buffer allocation belongs to AVM
- [ ] Buffer is a CLOS class
  - [ ] buffer-value is not always simple array
- [ ] Add MetalBuffer/ClangBuffer, etc...
- [ ] Provide bref 
- [ ] Transfer arrays via facet API
- [ ] JIT=1 is a default behaviour
- [ ] AVM/Buffer as a CLOS class

```
source/apis/ahead-of-time.lisp:  (defparameter *aot-jit* (ctx:getenv :AOT))
source/apis/ahead-of-time.lisp:  (defparameter *aot-vm* (ctx:getenv :AOT_VM))
source/apis/iseq.lisp:(defparameter *jit-device* nil)
source/avm/buffer.lisp:(defparameter *device* :lisp "a keyword to indicate the device (being dispatched)")
source/avm/runtime.lisp:(defparameter *vm* nil)
```