### PR TITLE
CI: Remove CCL Support

### DIFF
--- a/.github/workflows/tests_on_push.yml
+++ b/.github/workflows/tests_on_push.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        lisp: [sbcl-bin, ccl-bin/1.12.2]
+        lisp: [sbcl-bin]
         backend: [lisp, clang]
         os: [ubuntu-latest]
         target:


### PR DESCRIPTION
- [ ] CCL is too slow to finish the unittest in 30mins
- [ ] should only tested when the pr is merged in main (with setting timeout <= 50mins)