### PR TITLE
some minor example/documentation/messages fixes and improvements

### DIFF
--- a/external/gguf/helpers.lisp
+++ b/external/gguf/helpers.lisp
@@ -9,7 +9,7 @@
 			      (loop repeat len collect (fast-read-byte buffer)))))
     (values (the string (babel:octets-to-string str :encoding :utf-8)) len)))
 
-(declaim (inline readf16-le readf32-le readf64-le caten/common.dtype:decode-float32 caten/common.dtype:decode-float64))
+(declaim (inline readf16-le readf32-le readf64-le))
 (defun readf16-le (buffer) (caten/common.dtype:decode-float16 (readu16-le buffer)))
 (defun readf32-le (buffer) (caten/common.dtype:decode-float32 (readu32-le buffer)))
 (defun readf64-le (buffer) (caten/common.dtype:decode-float64 (readu64-le buffer)))

--- a/external/onnx/defop.lisp
+++ b/external/onnx/defop.lisp
@@ -145,7 +145,7 @@
       
       (assert (= (length output) (length out-in-tensors))
 	      ()
-	      "Assertion Failed: Converter for (~a opset=~a) expected to return ~a tensors butgot ~a."
+	      "Assertion Failed: Converter for (~a opset=~a) expected to return ~a tensors but got ~a."
 	      (node-proto-op-type node-proto)
 	      (gp-opset-version graph-proto-helper)
 	      (length output)

--- a/source/aasm/tensor-ir.lisp
+++ b/source/aasm/tensor-ir.lisp
@@ -109,7 +109,7 @@ Typed: <Allocate OUT_ID <- (,@shape ,@stride) where from=from dtype=dtype nrank=
 	   (type (member :row :column) order))
   (assert (every #'(lambda (x) (or (symbolp x) (integerp x) (node-p x))) shape)
 	  ()
-	  "%make-tensor: Shape is designed as symbol (existing in the graph), integer or node.~%butgot ~a" shape)
+	  "%make-tensor: Shape is designed as symbol (existing in the graph), integer or node.~%but got ~a" shape)
   (when (= 0 (length shape))
     (assert (null from) () ":from for a scalar creation is ignored. Use %load instead.")
     (return-from %make-tensor (%salloc :dtype dtype :id id)))

--- a/source/apis/attrs.lisp
+++ b/source/apis/attrs.lisp
@@ -1,4 +1,4 @@
 (in-package :caten/apis)
 
-(defnode (:Special/VM :Pause/Backward) (JITAble) "During VM execution, the forward computation is paused at the point where this node exists."
+(defnode (:Special/VM :Pause/Backward) (JITAble) "During VM execution, forward computation is paused at the point where this node exists."
 	 :placeholder -1)

--- a/source/apis/facets.lisp
+++ b/source/apis/facets.lisp
@@ -9,7 +9,7 @@
 `change-facet` converts `obj` to the data type specified by direction.
 During the conversion process, it attempts to synchronize the Buffer (i.e., no copying is performed).
 
-In default, `:direction` could be one of :tensor, :simple-array, :array.
+By default, `:direction` could be one of :tensor, :simple-array, :array.
 
 Users can extend this method if needed.
 "))

--- a/source/apis/function.lisp
+++ b/source/apis/function.lisp
@@ -8,13 +8,13 @@
 [Func] -> <Lower> -> [FastGraph] -> <Simplifier> -> [Completed]
 ```
 
-`Func` is a syntax-sugar for generating lowered instructions defined in the `caten/aasm` package.
+`Func` (as the base class) is syntactic sugar for generating lowered instructions defined in the `caten/aasm` package.
 
-To properly lower the `Func`, You need to implement the following three methods:
+To properly lower the respective `Func`, you need to implement the following three methods:
 
 - lower: Lower the `Func` into a list of `caten/air:node`. This should return `caten/air:graph`.
-- forward: Create the type for the Tensor after computation. Be mindful of its lazy evaluation nature; do not perform the actual computation. `ShapeTracker` might help you. (use the `st` macro)
-- backward: Create the graph for backward of op given prev-grad. Return: `(values input_1.grad input_2.grad ...)`."))
+- forward: Create the type for the Tensor after computation. Be aware of its lazy evaluation nature; do not perform the actual computation. `ShapeTracker` might help you. (use the `st` macro)
+- backward: Create the graph for the backward computation of op given prev-grad. Return: `(values input_1.grad input_2.grad ...)`."))
 
 (defgeneric lower (op &rest nodes)
   (:documentation "
@@ -33,7 +33,7 @@ Lowers the Func into a list of `caten/air:node`. This should return caten/air:gr
 (forward op &rest tensors)
 ```
 
-Create the type for the Tensor after computation. Be mindful of its lazy evaluation nature; do not perform the actual computation. Use the `st` macro to create a new tensor.
+Create the type for the Tensor after computation. Be aware of its lazy evaluation nature; do not perform the actual computation. Use the `st` macro to create a new tensor.
 
 - op[Func] Func to forward.
 - tensors[list] list of input tensors."))
@@ -44,7 +44,7 @@ Create the type for the Tensor after computation. Be mindful of its lazy evaluat
 (backward op &optional prev-grad)
 ```
 
-Create the graph for backward of op given prev-grad. Return: `(values input_1.grad input_2.grad ...)`.
+Create the graph for the backward computation of op given prev-grad. Return: `(values input_1.grad input_2.grad ...)`.
 save-for-backward is determined automatically, so you do not have to consider about in-place operation.
 
 - op[Func] Func to backward.
@@ -66,6 +66,7 @@ save-for-backward is determined automatically, so you do not have to consider ab
           for nth upfrom 0
           do (setf (tensor-nth-output o) nth))
     (apply #'values outs)))
+
 ;; ~~ differentiable ops ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defclass IdentityNode (Func) nil)
 (defmethod forward ((op IdentityNode) &rest tensors) (st "A[~] -> A[~]" (tensors)))
@@ -148,7 +149,7 @@ Subscripts has the following notation:
 - `(a b c)` slices in the range of `[a, b)` with step `c`. `c` can be negative. In that case, b must be larger than a. For example: `(10 0 -1)` to reverse the elements in the axis.
 - `(:~ n)` to broadcast the axis, with the size of `n`
 
-It is supported to compose mutliple views; the viewed tensors can be created from the viewed tensors.
+It is supported to compose multiple views; the viewed tensors can be created from the viewed tensors.
 "
   (make-view-internal base subscripts))
 
@@ -211,7 +212,7 @@ Transposes the last two axes of the tensor
 (!transpose tensor &optional (dim0 1) (dim1 0))
 ```
 
-Transposes the `dim0` and `dim1`.
+Transposes `dim0` and `dim1`.
 "
   (declare (type tensor tensor))
   (let* ((range (range 0 (ndim tensor)))
@@ -226,7 +227,7 @@ Transposes the `dim0` and `dim1`.
 (!contiguous x &key (force nil))
 ```
 
-If the tensor is viewed, creates a copy of tensor with contiguous memory. Otherwise, returns the original tensor. If `force` is set to T, it always creates a copy.
+If the tensor is viewed, then creates a copy of tensor with contiguous memory. Otherwise, return the original tensor. If `force` is set to T, it always creates a copy.
 "
   (declare (type tensor x))
   (if (or force (tensor-views x))
@@ -798,7 +799,7 @@ Computes the reciprocal of sqrt x.
 ```
 Finds the `rank` th index components of the tensor.
 
-For example (!gid x 1) for (3 3) tensor is a `(0 1 2). (As a tip) by combining !gid with !where, you can implement pseudo a random accessing of the tensor. For example:
+For example (!gid x 1) for (3 3) tensor is a `(0 1 2). (As a hint) by combining !gid with !where, you can implement a pseudo random access of the tensor. For example:
 "
   (declare (type tensor tensor) (type fixnum rank))
   (let* ((axis (normalize-axis tensor rank))
@@ -812,7 +813,7 @@ For example (!gid x 1) for (3 3) tensor is a `(0 1 2). (As a tip) by combining !
 ```
 (!normalize-axis ndim axis)
 ```
-Creates a tensor graph which normalizes the axis. If the axis is negative, it will be normalized to the positive axis.
+Creates a tensor graph which normalizes the axis. If the axis is negative, then it will be normalized to the positive axis.
 "
   (let ((ndim (->iconst ndim)) (axis (->iconst axis)))
     (!where (!< axis (iconst 0)) (!add axis ndim) axis)))

--- a/source/apis/helpers.lisp
+++ b/source/apis/helpers.lisp
@@ -71,7 +71,7 @@
 (with-no-grad &body body)
 ```
 
-Under the scope of `with-no-grad`, the gradient computation is disabled. This parameter should be set during inference, and the compiler will generate a more efficient code."
+Within the scope of `with-no-grad`, gradient computation is disabled. This parameter should be set during inference, such that the compiler will generate more efficient code."
   `(let ((*no-grad* t)) ,@body))
 
 (defun getattr-from-list (attrs id)
@@ -94,7 +94,7 @@ Reads and binds attributes from module.
 
 (defun normalize-axis (x n)
   (declare (type tensor x))
-  (assert (integerp n) () "axes should be designed as a number. butgot ~A" n)
+  (assert (integerp n) () "axes should be designed as a number, but got ~A" n)
   (if (< n 0) (+ (ndim x) n) n))
 
 (defun normalize-axes (x axes)

--- a/source/apis/high-level-ops.lisp
+++ b/source/apis/high-level-ops.lisp
@@ -71,6 +71,7 @@ Compute the ~a of the tensor.
   (defreduce !mean MeanNode "mean")
   (defreduce !max MaxReduce "maximum")
   (defreduce !min MinReduce "minimum"))
+
 ;; ~~~ gemm ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defmodule (Matmul (()) :where "A[~ i j] B[~ j k] -> A[~ i k]")
     ()
@@ -90,12 +91,13 @@ Compute the ~a of the tensor.
 (!matmul a b)
 ```
 
-Performs matrix multiplication between two tensors `a` and `b`.
+Performs matrix multiplication between the two tensors `a` and `b`.
 "
   (if (= (ndim a) (ndim b))
       (forward (make-instance 'Matmul) a b)
       (multiple-value-bind (a b) (bc "A[~ i j] B[~ j k] -> A[~ i j] B[~ j k]" (a b))
         (forward (make-instance 'Matmul) a b))))
+
 ;; ~~ math ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defmodule (SinHNode (()) :where "A[~] -> A[~]")
     ()
@@ -220,6 +222,7 @@ Computes the power of base with power."
        (return-from !expt (!mul (!square (!expt base (floor power 2))) (if (= 0 (mod power 2)) (!const base 1) base))))))
   (let ((power (if (numberp power) (!const base power) power)))
     (apply #'forward (ExptNode) (broadcast-elwise base power))))
+
 ;; ~~ Trunc/Ceil/Floor ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defmodule (TruncateNode (()) :where "A[~] -> A[~]")
     ()
@@ -258,6 +261,7 @@ Computes the power of base with power."
 ```
 "
   (forward (FloorNode) x))
+
 ;; ~~ Linalg ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defmodule (TrilNode ((&key (diagonal 0)) :diagonal diagonal) :where "A[~ n m] -> A[~ n m]")
     ()
@@ -347,6 +351,7 @@ Returns the indices of the maximum values along an axis.
 Returns the indices of the minimum values along an axis.
 "
   (forward (ArgMinNode :axis axis :keepdims keepdims) x))
+
 ;; ~~~ Statical Ops ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defmodule (VarianceNode ((&key (axis -1) (keepdims nil) (correction 1)) :axis axis :keepdims keepdims :correction correction))
     ()
@@ -389,6 +394,7 @@ Returns the standard deviation of the tensor elements along an axis.
 "
   (declare (type tensor x))
   (forward (StdNode :axis axis :keepdims keepdims :correction correction) x))
+
 ;; ~~~ Dimension Manipulation ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defmodel (SplitNode (sizes &key (dim 0)))
     ((sizes sizes :type (or fixnum list))
@@ -429,8 +435,8 @@ Returns the standard deviation of the tensor elements along an axis.
 
 Splits the tensor into multiple tensors along the specified dimension.
 
-If `sizes` is an integer, it splits into equally sized chunks if possible, otherwise the last chunk will be smaller.
-If `sizes` is a list, it splits into `(length sizes)` chunks with size in `dim` according to `size`.
+If `sizes` is an integer, then it splits into equally sized chunks if possible, otherwise the last chunk will be smaller.
+If `sizes` is a list, then it splits into `(length sizes)` chunks with size in `dim` according to `size`.
 
 Note: The dimension to split must be an integer.
 "
@@ -525,6 +531,7 @@ order is one of :column or :row. Shape is a list consisted of integers, symbols,
     (loop for i downfrom (- num-dims 2) to 0 do
       (setf (nth i strides) (!* (nth (+ i 1) strides) (->iconst (nth (+ i 1) shape)))))
     strides))
+
 ;; ~~ Etc ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defmodel (ClipNode () :where "A[~] MIN[~] MAX[~] -> A[~]") ())
 (defcall (clip ClipNode) (A[~] MIN[~] MAX[~])

--- a/source/apis/initializers.lisp
+++ b/source/apis/initializers.lisp
@@ -4,6 +4,7 @@
 ;;   All computational nodes that exhibit random behavior must depend on `RandNode`.
 ;;   it implements PRNG Generator based on threefry2x32.
 ;;   *rng-counter* and *manual-seed* should commonly be relied upon by all graphs.
+
 ;; ~~ Configurations ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defparameter *inference-mode* nil
   "
@@ -24,6 +25,7 @@ Sets `*inference-mode*=T` and `*no-grad*=T` within the scope of the body.
   `(with-no-grad
      (let ((*inference-mode* t))
        ,@body)))
+
 ;; ~~ randomness ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defun make-rng-counter ()
   (ctx:with-contextvar (:BACKEND "LISP")
@@ -46,6 +48,7 @@ Sets the seed for random operations.
 Sets the seed for random operations within the scope of the body.
 "
   `(let ((*manual-seed* ,seed) (*rng-counter* (make-rng-counter))) ,@body))
+
 ;; ~~~~ threefry2x32 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defun !idiv1 (x divisor) (!mul (!cast x :float32) (fconst (/ divisor))))
 (defun !shr (x shift dtype) (!cast (!idiv1 x (expt 2 shift)) dtype))
@@ -131,6 +134,7 @@ Sets the seed for random operations within the scope of the body.
       (t1 (%mul i a))
       (t2 (%add t1 b))
       (c  (%store x t2)))))
+
 ;; ~~ callers ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defun ax+b (shape a b &key (out nil) (dtype *default-float*) (order *default-order*))
   "

--- a/source/apis/merge-views.lisp
+++ b/source/apis/merge-views.lisp
@@ -437,5 +437,5 @@ for i in range(3):
       (optimize-aasm g :heavy-opt-threshold 0) ;; simplify the symbolic path by setting heavy-opt-threshold=0
       (assert (find write-to (graph-nodes g) :key #'node-writes :test #'find)
               ()
-              "%make-view-from-tracker: optimized-aasm purged ~a from the view graph. invaild simplifier?~%~a" write-to g)
+              "%make-view-from-tracker: optimized-aasm purged ~a from the view graph. invalid simplifier?~%~a" write-to g)
       g)))

--- a/source/apis/module.lisp
+++ b/source/apis/module.lisp
@@ -60,7 +60,7 @@ If you need to record Tensors for the backward process, now is the time to do so
 - tensors[List] a list of the input tensor.
 
 In the forward method, describe the operation to create a Tensor after computation.
-Be mindful of its lazy evaluation nature; do not perform the actual computation at this stage.
+Be aware of its lazy evaluation nature; do not perform the actual computation at this stage.
 The `st` macro in ShapeTracker is quite useful for creating the Tensor after the operation. If necessary, you may also include checks for additional attributes or slots here.
 If you specify ShapeTracker in `:where`, the defmodule macro will automatically generate the forward.
 Therefore, you must describe either `:where` or `:forward`.
@@ -174,6 +174,7 @@ The provided form does not match any of them:~%~a" method method method method f
 		 (map 'list #'tensor-id (module-outputs op))
 		 (map 'list #'node->id inputs) (append (module-attrs op) (list :metadata op)))))
        (defun ,name (,@constructor-args) (make-instance ',name :attrs (list ,@attrs))))))
+
 ;; ~~ State Dict ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defstruct State-Dict
   "

--- a/source/apis/shape-tracker.lisp
+++ b/source/apis/shape-tracker.lisp
@@ -52,7 +52,7 @@
 		   "ShapeTracker: Infinite rank can be used only once. ~a" subscript)
 	   (assert (= (or (position :~ subscripts) 0) 0)
 		   ()
-		   "ShapeTracker: Infinite rank must be placed at 0th axis.~%e.g.: A[~~ m n k]~%butgot: ~a" subscript)
+		   "ShapeTracker: Infinite rank must be placed at 0th axis.~%e.g.: A[~~ m n k]~%but got: ~a" subscript)
 	 (values (make-at (intern (symbol-name name) "KEYWORD") (- (length subscripts) count) subscripts) rest))))))
   (defun %parse-st (st)
     (declare (type string st))
@@ -191,7 +191,7 @@
 		      for shape in (nthcdr offset (tensor-shape tensor))
 		      if (gethash place solved)
 			do (when (and (numberp shape) (numberp (gethash place solved)))
-			     (assert (= shape (gethash place solved)) () "ShapeTracker: ~a. Invaild Shape Error.~% ~a should be ~a butgot ~a" (st-base st) place (gethash place solved) shape))
+			     (assert (= shape (gethash place solved)) () "ShapeTracker: ~a. Invalid Shape Error.~% ~a should be ~a but got ~a" (st-base st) place (gethash place solved) shape))
 		      else do
 			(setf (gethash place solved) shape))))
       (assert (every #'identity infinite-part)
@@ -226,10 +226,11 @@
                                             nil))))))
         (when return-solved (return-from %solve-st solved))
 	(apply #'values (map 'list #'make-new-tensor (st-aft st))))))
+  
   (defun parse-where (where)
     "Verifies the where form"
     (assert (every #'consp where) () "~a: Each element of where must be cons." where)
-    (assert (every (compose #'keywordp #'car) where) () "Invaild Syntax: WHERE = (KEYWORD . VALUE)~%in the ~a" where)
+    (assert (every (compose #'keywordp #'car) where) () "Invalid Syntax: WHERE = (KEYWORD . VALUE)~%in the ~a" where)
     `(list ,@(loop for (key . value) in where  collect `(cons ,key ,value)))))
 
 (defmacro st (st-notation (&rest input-tensors) &rest where)
@@ -245,7 +246,7 @@ Based on the notation of ShapeTracker, automatically generate the Tensor after f
 
 ### Infinite-Rank Notation
 
-`~` represents an inifinite-rank.
+`~` represents an infinite-rank.
 Positioned only in the first rank, and the rank height becomes infinite.
 Within this range, if there is a mismatch in shape, broadcasting is automatically applied.
 TODO: Add LazyAssertion which applies shape check even for symbols

--- a/source/common/contextvar.lisp
+++ b/source/common/contextvar.lisp
@@ -18,7 +18,7 @@ Usage:
   (defun oneof (name default &rest options)
     `(lambda (x)
        (when (null (find x ',@options))
-	 (warn "ContextVar: ~a expects one of ~a butgot ~a, setting ~a" ',name ',options x ',default)
+	 (warn "ContextVar: ~a expects one of ~a but got ~a, setting ~a" ',name ',options x ',default)
 	 (setf x ',default))
        x))
   (defun oneof-kw (name default &rest options)

--- a/source/common/dtype.lisp
+++ b/source/common/dtype.lisp
@@ -155,6 +155,7 @@
     (:int8 8)
     (:bool 1)))
 
+(declaim (inline caten/common.dtype:encode-float64 caten/common.dtype:decode-float32 caten/common.dtype:encode-float64 caten/common.dtype:decode-float64))
 (ieee-floats:make-float-converters encode-float64 decode-float64 11 52 t)
 (ieee-floats:make-float-converters encode-float32 decode-float32 8 23 t)
 (ieee-floats:make-float-converters encode-float16 decode-float16 5 10 t)

--- a/source/test-suite/test-air.lisp
+++ b/source/test-suite/test-air.lisp
@@ -1,6 +1,7 @@
 (in-package :caten/test-suite)
 
 (defun <node> (type writes reads &rest attrs) (apply #'make-node :Testing type writes reads attrs))
+
 (defun compare (graph expected
 		&key
 		  (slots `(caten/air::writes caten/air::reads caten/air::type caten/air::class))
@@ -13,13 +14,14 @@
 	(loop for node in (graph-nodes graph)
 	      for x = (find node expected :test #'eq-node)
 	      if (null x)
-		do (error "The node ~a is not appeared in the expected list." node)
+		do (error "The node ~a has not appeared in the expected list." node)
 	      else
 		do (setf expected (remove x expected :test #'eq-node)))
 	(return-from compare (every #'eq-node (graph-nodes graph) expected)))
     (if (null expected)
 	t
-	(error "Nodes ~a is not appeared in the simplified list." expected))))
+	(error "Nodes ~a has not appeared in the simplified list." expected))))
+
 (defmacro check-simplify (simplifier-name before after &key (shuffle-order t))
   `(compare
     (,simplifier-name
@@ -35,6 +37,7 @@
 (defnode (:Testing :Test-Sub1) () "")
 (defnode (:Testing :Test-X) () "")
 (defnode (:Testing :Test-L) () "")
+
 ;; ~~ tests ~~~~~~~~~~~~~~~~~~~~~~~~~~
 (defpattern number (x) `(guard ,x (numberp ,x)))
 (defsimplifier


### PR DESCRIPTION
some minor edits/improvements/fixes:
* move declaims about dtypes
(declaim (inline caten/common.dtype:encode-float64 caten/common.dtype:decode-float32 caten/common.dtype:encode-float64 caten/common.dtype:decode-float64))
from external/gguf/helpers.lisp to source/common/dtype.lisp
* fix end-to-end-example.lisp
* more information/slight restructuring in getting-started.lisp
* some edits in messages/comments (mostly in the caten/apis package)