### PR TITLE
Use MTLCodegen Directly

### DIFF
--- a/source/byoc/caten.byoc.asd
+++ b/source/byoc/caten.byoc.asd
@@ -2,7 +2,7 @@
   :description "BYOC (Bring Your Own Codegen) implements an extension of caten/codegen targeting multiple devices."
   :author "hikettei <ichndm@gmail.com>"
   :license "MIT"
-  :depends-on ("caten.codegen" "caten.runtime" "cffi" "flexi-streams" "float-features")
+  :depends-on ("caten.codegen" "caten.runtime" "cffi" "flexi-streams" "float-features" "babel" "cl-pack")
   :components ((:file "lisp")
                (:file "native")
                (:file "clang")

--- a/source/byoc/caten.byoc.asd
+++ b/source/byoc/caten.byoc.asd
@@ -2,10 +2,12 @@
   :description "BYOC (Bring Your Own Codegen) implements an extension of caten/codegen targeting multiple devices."
   :author "hikettei <ichndm@gmail.com>"
   :license "MIT"
+  :defsystem-depends-on ("cffi-grovel")
   :depends-on ("caten.codegen" "caten.runtime" "cffi" "flexi-streams" "float-features" "babel" "cl-pack")
   :components ((:file "lisp")
                (:file "native")
                (:file "clang")
+               (:cffi-wrapper-file "helpers/callback" :soname "callback_helper")
                (:file "metal")
                (:file "cuda")
                (:file "llvm")

--- a/source/byoc/helpers/callback.lisp
+++ b/source/byoc/helpers/callback.lisp
@@ -6,7 +6,7 @@
 typedef void (*callback_t)(void);
 static callback_t stored_cb = NULL;
 
-void* create_callback(void (*lisp_callback)(void)) {
+void* closure_cffi_callback(void (*lisp_callback)(void)) {
   stored_cb = lisp_callback;      
   return (^{ stored_cb(); });
 }

--- a/source/byoc/helpers/callback.lisp
+++ b/source/byoc/helpers/callback.lisp
@@ -2,12 +2,25 @@
 ;; Note2: create a closure that calls the stored callback (ensure it is thread-safe!)
 ;; Note3: this thing can be realized with only using cffi?
 (c
-"#include <stdio.h>
+"#ifdef __APPLE__
+#include <stdio.h>
+
 typedef void (*callback_t)(void);
 static callback_t stored_cb = NULL;
 
 void* closure_cffi_callback(void (*lisp_callback)(void)) {
-  stored_cb = lisp_callback;      
-  return (^{ stored_cb(); });
+    stored_cb = lisp_callback;
+    return (^{ stored_cb(); });
 }
+
+#else
+
+#include <stdio.h>
+
+void* closure_cffi_callback(void (*lisp_callback)(void)) {
+    fprintf(stderr, \"Error(caten/byoc/helper/callback.lisp): Apple Blocks extension not supported on this platform.\n\");
+    return NULL; 
+}
+
+#endif
 ")

--- a/source/byoc/helpers/callback.lisp
+++ b/source/byoc/helpers/callback.lisp
@@ -1,0 +1,13 @@
+;; Note1: only macOS should need this
+;; Note2: create a closure that calls the stored callback (ensure it is thread-safe!)
+;; Note3: this thing can be realized with only using cffi?
+(c
+"#include <stdio.h>
+typedef void (*callback_t)(void);
+static callback_t stored_cb = NULL;
+
+void* create_callback(void (*lisp_callback)(void)) {
+  stored_cb = lisp_callback;      
+  return (^{ stored_cb(); });
+}
+")

--- a/source/byoc/metal.lisp
+++ b/source/byoc/metal.lisp
@@ -67,7 +67,9 @@
 
 (defun mtl-compile-source (source
                            &key
-                             (fmodules-cache-path "./.caten_cache/metal/")
+                             (fmodules-cache-path
+                              #+darwin(progn "~/Library/Caches")
+                              #-darwin(progn "~/.cache"))
                            &aux
                              (service (MTLCodeGenServiceCreate "caten"))
                              (params (format nil "-fno-fast-math -std=metal3.1 --driver-mode=metal -x metal -fmodules-cache-path=~a -fno-caret-diagnostics" fmodules-cache-path))

--- a/source/byoc/metal.lisp
+++ b/source/byoc/metal.lisp
@@ -8,7 +8,7 @@
    #:define-auto-scheduler))
 
 (in-package :caten/byoc/metal)
-;; [TODO] Assert PARALLEL == 0
+
 (defconstant +request-type-compile+ 13)
 
 (defun ensure-foreign-library ()
@@ -75,6 +75,7 @@
                              (params (format nil "-fno-fast-math -std=metal3.1 --driver-mode=metal -x metal -fmodules-cache-path=~a -fno-caret-diagnostics" fmodules-cache-path))
                              (*callback-handler* :ready))
   (declare (type foreign-pointer service) (type string source params))
+  (assert (<= (ctx:getenv :PARALLEL) 1) () "METAL does not support parallel compilation.")
   (let ((request (make-request-form source params)))
     (with-foreign-string (*request request)
       (MTLCodeGenServiceBuildRequest

--- a/source/byoc/native.lisp
+++ b/source/byoc/native.lisp
@@ -45,7 +45,7 @@
       (when (getattr item :rendered-object)
         (format t "~a"
                 (with-output-to-string (tmp)
-                  (format tmp "~%[Blueprint: ~A]:~%~A~%Disassembly for ~a:~%```~%" (getattr item :name) (getattr item :rendered-object) (getattr item :name))
+                  ;; (format tmp "~%[Blueprint: ~A]:~%~A~%Disassembly for ~a:~%```~%" (getattr item :name) (getattr item :rendered-object) (getattr item :name))
                   (disassemble (compile nil (getattr item :rendered-object)) :stream tmp)
                   (format tmp "~%```~%"))))))
   (dolist (item items)

--- a/source/codegen/exprify.lisp
+++ b/source/codegen/exprify.lisp
@@ -466,7 +466,7 @@ Return: (values new-for-replacements if-statement[optional])"
     idx
 
     ))
-
+;; todo
 (defun test ()
   (mutate-for-as-space
    (make-node :RENDER :FOR nil nil

--- a/source/codegen/jit.lisp
+++ b/source/codegen/jit.lisp
@@ -419,6 +419,9 @@ Applies the JIT compilation for the given Runtime. backend is a keyword defined 
   (when (null is-jit)
     (setf (runtime-buffer-type runtime) buffer-class)
     (return-from jit runtime))
+  ;; METAL does not parallel compilation
+  (when (eql backend :metal)
+    (assert (<= (ctx:getenv :PARALLEL) 1) () "METAL does not support parallel compilation. Set PARALLEL=0"))
   (caten/isl:with-isl-context ;; Note: Need this to ensure isl objected allocated here are not cached and not used by other compiling sessions.
     (when (= 2 (ctx:getenv :DOT)) (->dot (runtime-graph runtime) :title "Base Graph"))
     (run-type-infer runtime)


### PR DESCRIPTION
- [ ] start by generating naive code for metal
- [ ] running test in ci
- [ ] then start working with auto scheduler
- [x] use MTLCompiler directly with some reverse engineering (#399 as prerequisite)
- [x] uiop:launch-program is slow on macOS but metal is fast which is ready for implementing beam
- [ ] xcrun metal ... is taking 3s but this could be boiled down to 0.03sec