### PR TITLE
[WIP] Add caten/runtime/ops.lisp

### DIFF
--- a/source/runtime/caten.runtime.asd
+++ b/source/runtime/caten.runtime.asd
@@ -7,4 +7,5 @@
   :components ((:file "buffer")
                (:file "profile")
                (:file "runtime")
+               (:file "ops")
                (:file "package")))

--- a/source/runtime/ops.lisp
+++ b/source/runtime/ops.lisp
@@ -14,4 +14,8 @@
 
   )
 
+;; [TODO] Caten V2 TensorParallel
+(defun %shard ())
+(defun %gather())
+
 

--- a/source/runtime/ops.lisp
+++ b/source/runtime/ops.lisp
@@ -1,0 +1,17 @@
+(defpackage :caten/runtime/ops
+  (:documentation ":caten/runtime/ops defines the major components for constructing GraphRuntime.")
+  (:use :cl :caten/air)
+  (:export
+
+   ))
+(in-package :caten/runtime/ops)
+;; [TODO]
+;; - Remove defnode in jit.lisp (e.g.: JIT_KERNEL), move to here!
+;; -
+;; -
+
+(defun %fcall ()
+
+  )
+
+

--- a/source/runtime/ops.lisp
+++ b/source/runtime/ops.lisp
@@ -5,17 +5,32 @@
 
    ))
 (in-package :caten/runtime/ops)
+;; How about this? we move the definition and constructor of irs to:
+;; ./source/ir
+;; ./source/ir/tensor/
+;; ./source/ir/runtime/
+;; ./source/ir/codegen/
+
+;; Our Goal is turn every node as a compilable (e.g.: creating any runtime from our IR)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+
+  (defnode (:Runtime :KERNEL_CALL) ()
+           "The node :KERNEL_CALL calls a compiled kernel."
+
+           )
+
+)
+
 ;; [TODO]
 ;; - Remove defnode in jit.lisp (e.g.: JIT_KERNEL), move to here!
-;; -
+;; - [Feat] TypeInferenceを統一的にしたい。
 ;; -
 
-(defun %fcall ()
-
+(defun %kernel_call ()
   )
 
-;; [TODO] Caten V2 TensorParallel
-(defun %shard ())
-(defun %gather())
+;; [TO COME] Caten V2 TensorParallel
+(defun %shard ()) ;; Breaks the tensor (todo: key axis)
+(defun %gather ())
 
 


### PR DESCRIPTION
### RuntimeGraph

everything is just for making exportable `RuntimeGraph` DAG.

RuntimeGraph components are:

```
%call (calls jit function)
%shard (TODO: TensorParallel)
%gather (TODO: TensorParallel)
```

- [ ] TODO: Move ShapeInference to .aasm?